### PR TITLE
Add subtitle to library and player screen

### DIFF
--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/converter/LibraryPageResponseConverter.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/converter/LibraryPageResponseConverter.kt
@@ -17,6 +17,7 @@ class LibraryPageResponseConverter @Inject constructor() {
             Book(
                 id = it.id,
                 title = title,
+                subtitle = it.media.metadata.subtitle,
                 author = it.media.metadata.authorName,
                 duration = it.media.duration.toInt(),
             )

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/converter/RecentListeningResponseConverter.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/converter/RecentListeningResponseConverter.kt
@@ -19,6 +19,7 @@ class RecentListeningResponseConverter @Inject constructor() {
             RecentBook(
                 id = it.id,
                 title = it.media.metadata.title,
+                subtitle = it.media.metadata.subtitle,
                 author = it.media.metadata.authorName,
                 listenedPercentage = progress[it.id]?.second?.let { it * 100 }?.toInt(),
                 listenedLastUpdate = progress[it.id]?.first,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/user/PersonalizedFeedResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/user/PersonalizedFeedResponse.kt
@@ -20,5 +20,6 @@ data class PersonalizedFeedItemMediaResponse(
 
 data class PersonalizedFeedItemMetadataResponse(
     val title: String,
+    val subtitle: String?,
     val authorName: String,
 )

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/converter/BookResponseConverter.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/converter/BookResponseConverter.kt
@@ -60,6 +60,7 @@ class BookResponseConverter @Inject constructor() {
         return DetailedItem(
             id = item.id,
             title = item.media.metadata.title,
+            subtitle = item.media.metadata.subtitle,
             author = item.media.metadata.authors?.joinToString(", ", transform = LibraryAuthorResponse::name),
             files = item
                 .media

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/converter/LibrarySearchItemsConverter.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/converter/LibrarySearchItemsConverter.kt
@@ -14,6 +14,7 @@ class LibrarySearchItemsConverter @Inject constructor() {
             Book(
                 id = it.id,
                 title = title,
+                subtitle = it.media.metadata.subtitle,
                 author = it.media.metadata.authorName,
                 duration = it.media.duration.toInt(),
             )

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/model/BookResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/model/BookResponse.kt
@@ -15,6 +15,7 @@ data class BookMedia(
 
 data class LibraryMetadataResponse(
     val title: String,
+    val subtitle: String?,
     val authors: List<LibraryAuthorResponse>?,
     val description: String?,
     val publisher: String?,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/model/LibraryItemsResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/model/LibraryItemsResponse.kt
@@ -17,5 +17,6 @@ data class Media(
 
 data class LibraryMetadata(
     val title: String?,
+    val subtitle: String?,
     val authorName: String?,
 )

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/podcast/converter/PodcastPageResponseConverter.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/podcast/converter/PodcastPageResponseConverter.kt
@@ -17,6 +17,7 @@ class PodcastPageResponseConverter @Inject constructor() {
             Book(
                 id = it.id,
                 title = title,
+                subtitle = null,
                 author = it.media.metadata.author,
                 duration = it.media.duration.toInt(),
             )

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/podcast/converter/PodcastResponseConverter.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/podcast/converter/PodcastResponseConverter.kt
@@ -59,6 +59,7 @@ class PodcastResponseConverter @Inject constructor() {
         return DetailedItem(
             id = item.id,
             title = item.media.metadata.title,
+            subtitle = null,
             libraryId = item.libraryId,
             author = item.media.metadata.author,
             localProvided = false,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/podcast/converter/PodcastSearchItemsConverter.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/podcast/converter/PodcastSearchItemsConverter.kt
@@ -15,6 +15,7 @@ class PodcastSearchItemsConverter @Inject constructor() {
                 Book(
                     id = it.id,
                     title = title,
+                    subtitle = null,
                     author = it.media.metadata.author,
                     duration = it.media.duration.toInt(),
                 )

--- a/app/src/main/java/org/grakovne/lissen/content/cache/LocalCacheModule.kt
+++ b/app/src/main/java/org/grakovne/lissen/content/cache/LocalCacheModule.kt
@@ -32,6 +32,7 @@ object LocalCacheModule {
             .addMigrations(MIGRATION_3_4)
             .addMigrations(MIGRATION_4_5)
             .addMigrations(MIGRATION_5_6)
+            .addMigrations(MIGRATION_6_7)
             .build()
     }
 

--- a/app/src/main/java/org/grakovne/lissen/content/cache/Migrations.kt
+++ b/app/src/main/java/org/grakovne/lissen/content/cache/Migrations.kt
@@ -96,3 +96,10 @@ val MIGRATION_5_6 = object : Migration(5, 6) {
         db.execSQL("ALTER TABLE detailed_books ADD COLUMN publisher TEXT")
     }
 }
+
+val MIGRATION_6_7 = object : Migration(6, 7) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE detailed_books ADD COLUMN subtitle TEXT")
+    }
+
+}

--- a/app/src/main/java/org/grakovne/lissen/content/cache/converter/CachedBookEntityConverter.kt
+++ b/app/src/main/java/org/grakovne/lissen/content/cache/converter/CachedBookEntityConverter.kt
@@ -11,6 +11,7 @@ class CachedBookEntityConverter @Inject constructor() {
     fun apply(entity: BookEntity): Book = Book(
         id = entity.id,
         title = entity.title,
+        subtitle = entity.subtitle,
         author = entity.author,
         duration = entity.duration,
     )

--- a/app/src/main/java/org/grakovne/lissen/content/cache/converter/CachedBookEntityDetailedConverter.kt
+++ b/app/src/main/java/org/grakovne/lissen/content/cache/converter/CachedBookEntityDetailedConverter.kt
@@ -14,6 +14,7 @@ class CachedBookEntityDetailedConverter @Inject constructor() {
     fun apply(entity: CachedBookEntity): DetailedItem = DetailedItem(
         id = entity.detailedBook.id,
         title = entity.detailedBook.title,
+        subtitle = entity.detailedBook.subtitle,
         author = entity.detailedBook.author,
         libraryId = entity.detailedBook.libraryId,
         localProvided = true,

--- a/app/src/main/java/org/grakovne/lissen/content/cache/converter/CachedBookEntityRecentConverter.kt
+++ b/app/src/main/java/org/grakovne/lissen/content/cache/converter/CachedBookEntityRecentConverter.kt
@@ -11,6 +11,7 @@ class CachedBookEntityRecentConverter @Inject constructor() {
     fun apply(entity: BookEntity, currentTime: Pair<Long, Double>?): RecentBook = RecentBook(
         id = entity.id,
         title = entity.title,
+        subtitle = entity.subtitle,
         author = entity.author,
         listenedLastUpdate = currentTime?.first ?: 0,
         listenedPercentage = currentTime

--- a/app/src/main/java/org/grakovne/lissen/content/cache/dao/CachedBookDao.kt
+++ b/app/src/main/java/org/grakovne/lissen/content/cache/dao/CachedBookDao.kt
@@ -28,6 +28,7 @@ interface CachedBookDao {
         val bookEntity = BookEntity(
             id = book.id,
             title = book.title,
+            subtitle = book.subtitle,
             author = book.author,
             duration = book.chapters.sumOf { it.duration }.toInt(),
             libraryId = book.libraryId,

--- a/app/src/main/java/org/grakovne/lissen/content/cache/entity/CachedBookEntity.kt
+++ b/app/src/main/java/org/grakovne/lissen/content/cache/entity/CachedBookEntity.kt
@@ -34,6 +34,7 @@ data class CachedBookEntity(
 data class BookEntity(
     @PrimaryKey val id: String,
     val title: String,
+    val subtitle: String?,
     val author: String?,
     val year: String?,
     val abstract: String?,

--- a/app/src/main/java/org/grakovne/lissen/domain/Book.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/Book.kt
@@ -2,6 +2,7 @@ package org.grakovne.lissen.domain
 
 data class Book(
     val id: String,
+    val subtitle: String?,
     val title: String,
     val author: String?,
     val duration: Int,

--- a/app/src/main/java/org/grakovne/lissen/domain/DetailedItem.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/DetailedItem.kt
@@ -5,6 +5,7 @@ import java.io.Serializable
 data class DetailedItem(
     val id: String,
     val title: String,
+    val subtitle: String?,
     val author: String?,
     val publisher: String?,
     val year: String?,

--- a/app/src/main/java/org/grakovne/lissen/domain/RecentBook.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/RecentBook.kt
@@ -3,6 +3,7 @@ package org.grakovne.lissen.domain
 data class RecentBook(
     val id: String,
     val title: String,
+    val subtitle: String?,
     val author: String?,
     val listenedPercentage: Int?,
     val listenedLastUpdate: Long?,

--- a/app/src/main/java/org/grakovne/lissen/playback/service/PlaybackService.kt
+++ b/app/src/main/java/org/grakovne/lissen/playback/service/PlaybackService.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import androidx.annotation.OptIn
+import androidx.core.net.toUri
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -27,6 +28,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import org.grakovne.lissen.LissenApplication
 import org.grakovne.lissen.channel.audiobookshelf.common.api.RequestHeadersProvider
 import org.grakovne.lissen.common.withTrustedCertificates
 import org.grakovne.lissen.content.LissenMediaProvider
@@ -34,6 +36,7 @@ import org.grakovne.lissen.domain.BookFile
 import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.MediaProgress
 import org.grakovne.lissen.persistence.preferences.LissenSharedPreferences
+import java.io.File
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -156,6 +159,12 @@ class PlaybackService : MediaSessionService() {
                         onFailure = { null },
                     )
 
+                val cachedCover = cover?.let {
+                    val f = File.createTempFile(book.id, null, LissenApplication.appContext.cacheDir)
+                    f.writeBytes(it)
+                    f
+                }
+
                 val sourceFactory = buildDataSourceFactory()
 
                 val playingQueue = book
@@ -168,8 +177,7 @@ class PlaybackService : MediaSessionService() {
                                     val mediaData = MediaMetadata.Builder()
                                         .setTitle(file.name)
                                         .setArtist(book.title)
-
-                                    cover?.let { mediaData.setArtworkData(it, PICTURE_TYPE_FRONT_COVER) }
+                                        .setArtworkUri(cachedCover?.toUri())
 
                                     val mediaItem = MediaItem.Builder()
                                         .setMediaId(file.id)

--- a/app/src/main/java/org/grakovne/lissen/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/navigation/AppNavHost.kt
@@ -82,10 +82,11 @@ fun AppNavHost(
             }
 
             composable(
-                route = "player_screen/{bookId}?bookTitle={bookTitle}",
+                route = "player_screen/{bookId}?bookTitle={bookTitle}&bookSubtitle={bookSubtitle}",
                 arguments = listOf(
                     navArgument("bookId") { type = NavType.StringType },
                     navArgument("bookTitle") { type = NavType.StringType; nullable = true },
+                    navArgument("bookSubtitle") { type = NavType.StringType; nullable = true },
                 ),
                 enterTransition = { enterTransition },
                 exitTransition = { exitTransition },
@@ -94,12 +95,14 @@ fun AppNavHost(
             ) { navigationStack ->
                 val bookId = navigationStack.arguments?.getString("bookId") ?: return@composable
                 val bookTitle = navigationStack.arguments?.getString("bookTitle") ?: ""
+                val bookSubtitle = navigationStack.arguments?.getString("bookSubtitle")
 
                 PlayerScreen(
                     navController = navigationService,
                     imageLoader = imageLoader,
                     bookId = bookId,
                     bookTitle = bookTitle,
+                    bookSubtitle = bookSubtitle,
                 )
             }
 

--- a/app/src/main/java/org/grakovne/lissen/ui/navigation/AppNavigationService.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/navigation/AppNavigationService.kt
@@ -16,11 +16,12 @@ class AppNavigationService(
         }
     }
 
-    fun showPlayer(bookId: String, bookName: String) {
-        host.navigate("player_screen/$bookId?bookTitle=$bookName") {
+    fun showPlayer(bookId: String, bookTitle: String, bookSubtitle: String?) {
+        host.navigate("player_screen/$bookId?bookTitle=$bookTitle&bookSubtitle=$bookSubtitle") {
             launchSingleTop = true
 
-            host.currentBackStackEntry?.arguments?.putString("bookTitle", bookName)
+            host.currentBackStackEntry?.arguments?.putString("bookTitle", bookTitle)
+            host.currentBackStackEntry?.arguments?.putString("bookSubTitle", bookSubtitle)
         }
     }
 

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/BookComposable.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/BookComposable.kt
@@ -83,19 +83,25 @@ fun BookComposable(
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
-            book
-                .author
-                ?.let {
-                    Spacer(modifier = Modifier.height(4.dp))
+
+            val info = listOf(book.subtitle, book.author)
+
+            info.any { it != null }.let {
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+
+            info.forEach {
+                it?.let {
                     Text(
                         text = it,
-                        style = MaterialTheme.typography.bodyMedium.copy(
+                        style = MaterialTheme.typography.bodySmall.copy(
                             color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
                         ),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
+            }
         }
 
         Spacer(modifier = Modifier.width(16.dp))

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/BookComposable.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/BookComposable.kt
@@ -52,7 +52,7 @@ fun BookComposable(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { navController.showPlayer(book.id, book.title) }
+            .clickable { navController.showPlayer(book.id, book.title, book.subtitle) }
             .testTag("bookItem_${book.id}")
             .padding(horizontal = 4.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -84,23 +84,30 @@ fun BookComposable(
                 overflow = TextOverflow.Ellipsis,
             )
 
-            val info = listOf(book.subtitle, book.author)
-
-            info.any { it != null }.let {
+            if (book.subtitle != null || book.author != null) {
                 Spacer(modifier = Modifier.height(4.dp))
             }
 
-            info.forEach {
-                it?.let {
-                    Text(
-                        text = it,
-                        style = MaterialTheme.typography.bodySmall.copy(
-                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
-                        ),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
+            book.subtitle?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            book.author?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
         }
 

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/MiniPlayerComposable.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/MiniPlayerComposable.kt
@@ -117,7 +117,7 @@ fun MiniPlayerComposable(
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(colorScheme.background)
-                    .clickable { navController.showPlayer(book.id, book.title) }
+                    .clickable { navController.showPlayer(book.id, book.title, book.subtitle) }
                     .padding(horizontal = 20.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -155,17 +155,27 @@ fun MiniPlayerComposable(
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                     )
-                    arrayOf(book.subtitle, book.author).forEach {
-                        it?.let {
-                            Text(
-                                text = it,
-                                style = typography.bodyMedium.copy(
-                                    color = colorScheme.onBackground.copy(alpha = 0.6f),
-                                ),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
+
+                    book.subtitle?.let {
+                        Text(
+                            text = it,
+                            style = typography.bodySmall.copy(
+                                color = colorScheme.onBackground.copy(alpha = 0.6f),
+                            ),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+
+                    book.author?.let {
+                        Text(
+                            text = it,
+                            style = typography.bodySmall.copy(
+                                color = colorScheme.onBackground.copy(alpha = 0.6f),
+                            ),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
                     }
                 }
 

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/MiniPlayerComposable.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/MiniPlayerComposable.kt
@@ -155,9 +155,8 @@ fun MiniPlayerComposable(
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                     )
-                    book
-                        .author
-                        ?.let {
+                    arrayOf(book.subtitle, book.author).forEach {
+                        it?.let {
                             Text(
                                 text = it,
                                 style = typography.bodyMedium.copy(
@@ -167,6 +166,7 @@ fun MiniPlayerComposable(
                                 overflow = TextOverflow.Ellipsis,
                             )
                         }
+                    }
                 }
 
                 Column(

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/RecentBooksComposable.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/RecentBooksComposable.kt
@@ -178,17 +178,17 @@ fun RecentBookItemComposable(
 
             Spacer(modifier = Modifier.height(4.dp))
 
-            book.author?.let {
-                Text(
-                    text = book.author,
-                    style = MaterialTheme.typography.bodySmall.copy(
-                        color = MaterialTheme.colorScheme.onBackground.copy(
-                            alpha = 0.6f,
+            arrayOf(book.subtitle, book.author).forEach {
+                it?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
                         ),
-                    ),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/RecentBooksComposable.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/RecentBooksComposable.kt
@@ -94,7 +94,7 @@ fun RecentBookItemComposable(
     Column(
         modifier = Modifier
             .width(width)
-            .clickable { navController.showPlayer(book.id, book.title) },
+            .clickable { navController.showPlayer(book.id, book.title, book.subtitle) },
     ) {
         val context = LocalContext.current
         var coverLoading by remember { mutableStateOf(true) }
@@ -178,17 +178,26 @@ fun RecentBookItemComposable(
 
             Spacer(modifier = Modifier.height(4.dp))
 
-            arrayOf(book.subtitle, book.author).forEach {
-                it?.let {
-                    Text(
-                        text = it,
-                        style = MaterialTheme.typography.bodySmall.copy(
-                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
-                        ),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
+            book.subtitle?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            book.author?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
         }
     }

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/placeholder/LibraryPlaceholderComposable.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/placeholder/LibraryPlaceholderComposable.kt
@@ -65,7 +65,18 @@ fun LibraryItemPlaceholderComposable() {
             Box(
                 modifier = Modifier
                     .fillMaxWidth(0.6f)
-                    .height(12.dp)
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .shimmer()
+                    .background(Color.Gray),
+            )
+
+            Spacer(modifier = Modifier.height(2.dp))
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.6f)
+                    .height(8.dp)
                     .clip(RoundedCornerShape(4.dp))
                     .shimmer()
                     .background(Color.Gray),

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/placeholder/RecentBooksPlaceholderComposable.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/library/composables/placeholder/RecentBooksPlaceholderComposable.kt
@@ -82,7 +82,7 @@ fun RecentBookItemComposable(
             Text(
                 color = Color.Transparent,
                 text = "Crime and Punishment",
-                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
                 maxLines = 1,
                 modifier = Modifier
                     .clip(RoundedCornerShape(4.dp))
@@ -90,14 +90,28 @@ fun RecentBookItemComposable(
                     .background(Color.Gray),
             )
             if (libraryViewModel.fetchPreferredLibraryType() == LibraryType.LIBRARY) {
-                Spacer(modifier = Modifier.height(6.dp))
+                Spacer(modifier = Modifier.height(8.dp))
 
                 Text(
                     color = Color.Transparent,
                     text = "Fyodor Dostoevsky",
+                    style = MaterialTheme.typography.bodySmall,
                     maxLines = 1,
                     modifier = Modifier
-                        .clip(RoundedCornerShape(4.dp))
+                        .clip(RoundedCornerShape(2.dp))
+                        .shimmer()
+                        .background(Color.Gray),
+                )
+
+                Spacer(modifier = Modifier.height(2.dp))
+
+                Text(
+                    color = Color.Transparent,
+                    text = "Fyodor Dostoevsky",
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(2.dp))
                         .shimmer()
                         .background(Color.Gray),
                 )

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/player/PlayerScreen.kt
@@ -81,6 +81,7 @@ fun PlayerScreen(
     imageLoader: ImageLoader,
     bookId: String,
     bookTitle: String,
+    bookSubtitle: String?,
 ) {
     val context = LocalContext.current
 
@@ -220,7 +221,7 @@ fun PlayerScreen(
                         horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         if (!isPlaybackReady) {
-                            TrackDetailsPlaceholderComposable(bookTitle)
+                            TrackDetailsPlaceholderComposable(bookTitle, bookSubtitle)
                         } else {
                             TrackDetailsComposable(
                                 viewModel = playerViewModel,
@@ -285,6 +286,18 @@ fun PlayerScreen(
                         overflow = TextOverflow.Ellipsis,
                         color = colorScheme.onSurface,
                     )
+
+                    bookSubtitle?.let {
+                        Spacer(Modifier.height(4.dp))
+
+                        Text(
+                            text = it,
+                            style = typography.titleSmall,
+                            color = colorScheme.onBackground.copy(alpha = 0.6f),
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
 
                     Spacer(Modifier.height(8.dp))
 

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/player/composable/TrackDetailsComposable.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/player/composable/TrackDetailsComposable.kt
@@ -90,6 +90,18 @@ fun TrackDetailsComposable(
                 .padding(horizontal = 16.dp),
         )
 
+        book?.subtitle?.let {
+            Text(
+                text = it,
+                style = typography.bodyMedium,
+                color = colorScheme.onBackground.copy(alpha = 0.6f),
+                textAlign = TextAlign.Center,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
         Spacer(modifier = Modifier.height(4.dp))
 
         Text(

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/player/composable/TrackDetailsComposable.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/player/composable/TrackDetailsComposable.kt
@@ -90,6 +90,8 @@ fun TrackDetailsComposable(
                 .padding(horizontal = 16.dp),
         )
 
+        Spacer(modifier = Modifier.height(4.dp))
+
         book?.subtitle?.let {
             Text(
                 text = it,
@@ -100,9 +102,9 @@ fun TrackDetailsComposable(
                 maxLines = 1,
                 modifier = Modifier.fillMaxWidth(),
             )
-        }
 
-        Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(4.dp))
+        }
 
         Text(
             text = provideChapterNumberTitle(

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/player/composable/placeholder/TrackDetailsPlaceholderComposable.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/player/composable/placeholder/TrackDetailsPlaceholderComposable.kt
@@ -29,6 +29,7 @@ import org.grakovne.lissen.R
 @Composable
 fun TrackDetailsPlaceholderComposable(
     bookTitle: String,
+    bookSubtitle: String?,
     modifier: Modifier = Modifier,
 ) {
     val configuration = LocalConfiguration.current
@@ -60,7 +61,21 @@ fun TrackDetailsPlaceholderComposable(
             maxLines = 2,
             modifier = Modifier.padding(horizontal = 16.dp),
         )
+
         Spacer(modifier = Modifier.height(4.dp))
+
+        bookSubtitle?.let {
+            Text(
+                    text = it,
+                    style = typography.bodyMedium,
+                    color = colorScheme.onBackground.copy(alpha = 0.6f),
+                    textAlign = TextAlign.Center,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+        }
 
         Text(
             text = stringResource(R.string.player_screen_now_playing_title_chapter_of, 100, "1000"),


### PR DESCRIPTION
Hi there,
Thanks for developing a native UI for Audiobookshelf. The app seems fantastic, and I look forward to using it.

The only issue that prevents me from using Lissen is that the subtitles of the audiobooks are not displayed anywhere in the UI. Therefore, I thought I would create a PR for that, which you might want to merge if you think this is a good addition. I added the subtitle to the book list, the recently played list, and the player screen. 

Missing subtitles that store information, like a book's position in a series, is specifically annoying for long series like The Wheel of Time (the German translation has 37 books, and I do not know the order of all the books). 

The app seems to hang on the player screen with my specific setup. However, I don't see how this would relate to my changes, so you might want to check whether you have the same issue. If you can't reproduce it, I would be happy to help. 