### PR TITLE
Adding release builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ output.json
 misc.xml
 deploymentTargetDropDown.xml
 render.experimental.xml
+.kotlin
 
 # Keystore files
 *.jks
@@ -31,3 +32,6 @@ google-services.json
 
 # Android Profiling
 *.hprof
+
+# Schemas
+app/schemas

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,11 +54,43 @@ android {
 
         buildConfigField("String", "ACRA_REPORT_LOGIN", "\"$acraReportLogin\"")
         buildConfigField("String", "ACRA_REPORT_PASSWORD", "\"$acraReportPassword\"")
+
+        if (project.hasProperty("RELEASE_STORE_FILE")) {
+            signingConfigs {
+                create("release") {
+                    storeFile = file(project.property("RELEASE_STORE_FILE")!!)
+                    storePassword = project.property("RELEASE_STORE_PASSWORD") as String?
+                    keyAlias = project.property("RELEASE_KEY_ALIAS") as String?
+                    keyPassword = project.property("RELEASE_KEY_PASSWORD") as String?
+
+                    // Optional, specify signing versions used
+                    enableV1Signing = true
+                    enableV2Signing = true
+                }
+            }
+        }
     }
 
     buildTypes {
-        release {}
+        release {
+            if (project.hasProperty("RELEASE_STORE_FILE")) {
+                signingConfig = signingConfigs.getByName("release")
+            }
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                    // Includes the default ProGuard rules files that are packaged with
+                    // the Android Gradle plugin. To learn more, go to the section about
+                    // R8 configuration files.
+                    getDefaultProguardFile("proguard-android-optimize.txt"),
+
+                    // Includes a local, custom Proguard rules file
+                    "proguard-rules.pro"
+            )
+        }
         debug {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = " (DEBUG)"
             matchingFallbacks.add("release")
             isDebuggable = true
         }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,15 @@
+# Gson uses generic type information stored in a class file when working with
+# fields. Proguard removes such information by default, keep it.
+-keepattributes Signature
+
+# This is also needed for R8 in compat mode since multiple
+# optimizations will remove the generic signature such as class
+# merging and argument removal. See:
+# https://r8.googlesource.com/r8/+/refs/heads/main/compatibility-faq.md#troubleshooting-gson-gson
+-keep class com.google.gson.reflect.TypeToken { *; }
+-keep class * extends com.google.gson.reflect.TypeToken
+
+# Optional. For using GSON @Expose annotation
+-keepattributes AnnotationDefault,RuntimeVisibleAnnotations
+-keep class com.google.gson.reflect.TypeToken { <fields>; }
+-keepclassmembers class **$TypeAdapterFactory { <fields>; }

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Lissen (DEBUG)</string>
+</resources>

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/api/ApiClientConfig.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/api/ApiClientConfig.kt
@@ -1,7 +1,9 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.api
 
+import androidx.annotation.Keep
 import org.grakovne.lissen.domain.connection.ServerRequestHeader
 
+@Keep
 data class ApiClientConfig(
     val host: String?,
     val token: String?,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/MediaProgressResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/MediaProgressResponse.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.model
 
+import androidx.annotation.Keep
+
+@Keep
 data class MediaProgressResponse(
     val libraryItemId: String,
     val episodeId: String?,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/auth/AuthMethodResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/auth/AuthMethodResponse.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.model.auth
 
+import androidx.annotation.Keep
+
+@Keep
 data class AuthMethodResponse(
     val authMethods: List<String> = emptyList(),
 )

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/connection/ConnectionInfoResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/connection/ConnectionInfoResponse.kt
@@ -1,14 +1,19 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.model.connection
 
+import androidx.annotation.Keep
+
+@Keep
 data class ConnectionInfoResponse(
     val user: ConnectionInfoUserResponse,
     val serverSettings: ConnectionInfoServerResponse?,
 )
 
+@Keep
 data class ConnectionInfoUserResponse(
     val username: String,
 )
 
+@Keep
 data class ConnectionInfoServerResponse(
     val version: String?,
     val buildNumber: String?,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/metadata/AuthorItemsResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/metadata/AuthorItemsResponse.kt
@@ -1,7 +1,9 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.model.metadata
 
+import androidx.annotation.Keep
 import org.grakovne.lissen.channel.audiobookshelf.library.model.LibraryItem
 
+@Keep
 data class AuthorItemsResponse(
     val libraryItems: List<LibraryItem>,
 )

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/metadata/LibraryResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/metadata/LibraryResponse.kt
@@ -1,9 +1,13 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.model.metadata
 
+import androidx.annotation.Keep
+
+@Keep
 data class LibraryResponse(
     val libraries: List<LibraryItemResponse>,
 )
 
+@Keep
 data class LibraryItemResponse(
     val id: String,
     val name: String,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/playback/PlaybackSessionResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/playback/PlaybackSessionResponse.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.model.playback
 
+import androidx.annotation.Keep
+
+@Keep
 data class PlaybackSessionResponse(
     val id: String,
     val libraryItemId: String,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/playback/PlaybackStartRequest.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/playback/PlaybackStartRequest.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.model.playback
 
+import androidx.annotation.Keep
+
+@Keep
 data class PlaybackStartRequest(
     val deviceInfo: DeviceInfo,
     val supportedMimeTypes: List<String>,
@@ -8,6 +11,7 @@ data class PlaybackStartRequest(
     val forceDirectPlay: Boolean,
 )
 
+@Keep
 data class DeviceInfo(
     val clientName: String,
     val deviceId: String,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/playback/ProgressSyncRequest.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/playback/ProgressSyncRequest.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.model.playback
 
+import androidx.annotation.Keep
+
+@Keep
 data class ProgressSyncRequest(
     val timeListened: Int,
     val duration: Double,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/user/CredentialsLoginRequest.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/user/CredentialsLoginRequest.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.model.user
 
+import androidx.annotation.Keep
+
+@Keep
 data class CredentialsLoginRequest(
     val username: String,
     val password: String,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/user/LoggedUserResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/user/LoggedUserResponse.kt
@@ -1,10 +1,14 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.model.user
 
+import androidx.annotation.Keep
+
+@Keep
 data class LoggedUserResponse(
     val user: User,
     val userDefaultLibraryId: String?,
 )
 
+@Keep
 data class User(
     val id: String,
     val token: String,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/user/PersonalizedFeedResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/user/PersonalizedFeedResponse.kt
@@ -1,11 +1,15 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.model.user
 
+import androidx.annotation.Keep
+
+@Keep
 data class PersonalizedFeedResponse(
     val id: String,
     val labelStringKey: String,
     val entities: List<PersonalizedFeedItemResponse>,
 )
 
+@Keep
 data class PersonalizedFeedItemResponse(
     val id: String,
     val libraryId: String,
@@ -13,11 +17,13 @@ data class PersonalizedFeedItemResponse(
     val updateAt: Long,
 )
 
+@Keep
 data class PersonalizedFeedItemMediaResponse(
     val id: String,
     val metadata: PersonalizedFeedItemMetadataResponse,
 )
 
+@Keep
 data class PersonalizedFeedItemMetadataResponse(
     val title: String,
     val subtitle: String?,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/user/UserInfoResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/common/model/user/UserInfoResponse.kt
@@ -1,11 +1,14 @@
 package org.grakovne.lissen.channel.audiobookshelf.common.model.user
 
+import androidx.annotation.Keep
 import org.grakovne.lissen.channel.audiobookshelf.common.model.MediaProgressResponse
 
+@Keep
 data class UserInfoResponse(
     val user: UserResponse,
 )
 
+@Keep
 data class UserResponse(
     val mediaProgress: List<MediaProgressResponse>?,
 )

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/model/BookResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/model/BookResponse.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.channel.audiobookshelf.library.model
 
+import androidx.annotation.Keep
+
+@Keep
 data class BookResponse(
     val id: String,
     val ino: String,
@@ -9,12 +12,14 @@ data class BookResponse(
     val ctimeMs: Long,
 )
 
+@Keep
 data class BookMedia(
     val metadata: LibraryMetadataResponse,
     val audioFiles: List<BookAudioFileResponse>?,
     val chapters: List<LibraryChapterResponse>?,
 )
 
+@Keep
 data class LibraryMetadataResponse(
     val title: String,
     val subtitle: String?,
@@ -25,17 +30,20 @@ data class LibraryMetadataResponse(
     val publishedYear: String?,
 )
 
+@Keep
 data class LibrarySeriesResponse(
     val id: String,
     val name: String,
     val sequence: String?,
 )
 
+@Keep
 data class LibraryAuthorResponse(
     val id: String,
     val name: String,
 )
 
+@Keep
 data class BookAudioFileResponse(
     val index: Int,
     val ino: String,
@@ -45,17 +53,20 @@ data class BookAudioFileResponse(
     val mimeType: String,
 )
 
+@Keep
 data class AudioFileMetadata(
     val filename: String,
     val ext: String,
     val size: Long,
 )
 
+@Keep
 data class AudioFileTag(
     val tagAlbum: String,
     val tagTitle: String,
 )
 
+@Keep
 data class LibraryChapterResponse(
     val start: Double,
     val end: Double,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/model/LibraryItemsResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/model/LibraryItemsResponse.kt
@@ -1,20 +1,26 @@
 package org.grakovne.lissen.channel.audiobookshelf.library.model
 
+import androidx.annotation.Keep
+
+@Keep
 data class LibraryItemsResponse(
     val results: List<LibraryItem>,
     val page: Int,
 )
 
+@Keep
 data class LibraryItem(
     val id: String,
     val media: Media,
 )
 
+@Keep
 data class Media(
     val duration: Double,
     val metadata: LibraryMetadata,
 )
 
+@Keep
 data class LibraryMetadata(
     val title: String?,
     val subtitle: String?,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/model/LibrarySearchResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/library/model/LibrarySearchResponse.kt
@@ -1,14 +1,19 @@
 package org.grakovne.lissen.channel.audiobookshelf.library.model
 
+import androidx.annotation.Keep
+
+@Keep
 data class LibrarySearchResponse(
     val book: List<LibrarySearchItemResponse>,
     val authors: List<LibrarySearchAuthorResponse>,
 )
 
+@Keep
 data class LibrarySearchItemResponse(
     val libraryItem: LibraryItem,
 )
 
+@Keep
 data class LibrarySearchAuthorResponse(
     val id: String,
     val name: String,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/podcast/model/PodcastItemsResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/podcast/model/PodcastItemsResponse.kt
@@ -1,20 +1,26 @@
 package org.grakovne.lissen.channel.audiobookshelf.podcast.model
 
+import androidx.annotation.Keep
+
+@Keep
 data class PodcastItemsResponse(
     val results: List<PodcastItem>,
     val page: Int,
 )
 
+@Keep
 data class PodcastItem(
     val id: String,
     val media: PodcastItemMedia,
 )
 
+@Keep
 data class PodcastItemMedia(
     val duration: Double,
     val metadata: PodcastMetadata,
 )
 
+@Keep
 data class PodcastMetadata(
     val title: String?,
     val author: String?,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/podcast/model/PodcastResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/podcast/model/PodcastResponse.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.channel.audiobookshelf.podcast.model
 
+import androidx.annotation.Keep
+
+@Keep
 data class PodcastResponse(
     val id: String,
     val ino: String,
@@ -9,11 +12,13 @@ data class PodcastResponse(
     val ctimeMs: Long,
 )
 
+@Keep
 data class PodcastMedia(
     val metadata: PodcastMediaMetadataResponse,
     val episodes: List<PodcastEpisodeResponse>?,
 )
 
+@Keep
 data class PodcastMediaMetadataResponse(
     val title: String,
     val author: String?,
@@ -21,6 +26,7 @@ data class PodcastMediaMetadataResponse(
     val publisher: String?,
 )
 
+@Keep
 data class PodcastEpisodeResponse(
     val id: String,
     val season: String?,
@@ -30,6 +36,7 @@ data class PodcastEpisodeResponse(
     val audioFile: PodcastAudioFileResponse,
 )
 
+@Keep
 data class PodcastAudioFileResponse(
     val index: Int,
     val ino: String,

--- a/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/podcast/model/PodcastSearchResponse.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/audiobookshelf/podcast/model/PodcastSearchResponse.kt
@@ -1,9 +1,13 @@
 package org.grakovne.lissen.channel.audiobookshelf.podcast.model
 
+import androidx.annotation.Keep
+
+@Keep
 data class PodcastSearchResponse(
     val podcast: List<PodcastSearchItemResponse>,
 )
 
+@Keep
 data class PodcastSearchItemResponse(
     val libraryItem: PodcastItem,
 )

--- a/app/src/main/java/org/grakovne/lissen/channel/common/ApiResult.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/common/ApiResult.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.channel.common
 
+import androidx.annotation.Keep
+
+@Keep
 sealed class ApiResult<T> {
     data class Success<T>(val data: T) : ApiResult<T>()
     data class Error<T>(val code: ApiError, val message: String? = null) : ApiResult<T>()

--- a/app/src/main/java/org/grakovne/lissen/channel/common/ChannelFilteringConfiguration.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/common/ChannelFilteringConfiguration.kt
@@ -1,8 +1,10 @@
 package org.grakovne.lissen.channel.common
 
+import androidx.annotation.Keep
 import org.grakovne.lissen.common.LibraryOrderingConfiguration
 import org.grakovne.lissen.common.LibraryOrderingOption
 
+@Keep
 data class ChannelFilteringConfiguration(
     val orderingOptions: List<LibraryOrderingOption>,
     val defaultOrdering: LibraryOrderingConfiguration,

--- a/app/src/main/java/org/grakovne/lissen/channel/common/ConnectionInfo.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/common/ConnectionInfo.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.channel.common
 
+import androidx.annotation.Keep
+
+@Keep
 data class ConnectionInfo(
     val username: String,
     val serverVersion: String?,

--- a/app/src/main/java/org/grakovne/lissen/channel/common/Pkce.kt
+++ b/app/src/main/java/org/grakovne/lissen/channel/common/Pkce.kt
@@ -1,5 +1,6 @@
 package org.grakovne.lissen.channel.common
 
+import androidx.annotation.Keep
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.util.Base64
@@ -33,6 +34,7 @@ private fun base64UrlEncode(bytes: ByteArray) = Base64
     .withoutPadding()
     .encodeToString(bytes)
 
+@Keep
 data class Pkce(
     val verifier: String,
     val challenge: String,

--- a/app/src/main/java/org/grakovne/lissen/common/LibraryOrderingConfiguration.kt
+++ b/app/src/main/java/org/grakovne/lissen/common/LibraryOrderingConfiguration.kt
@@ -1,7 +1,9 @@
 package org.grakovne.lissen.common
 
+import androidx.annotation.Keep
 import androidx.compose.runtime.saveable.Saver
 
+@Keep
 data class LibraryOrderingConfiguration(
     val option: LibraryOrderingOption,
     val direction: LibraryOrderingDirection,

--- a/app/src/main/java/org/grakovne/lissen/content/cache/CacheState.kt
+++ b/app/src/main/java/org/grakovne/lissen/content/cache/CacheState.kt
@@ -1,7 +1,9 @@
 package org.grakovne.lissen.content.cache
 
+import androidx.annotation.Keep
 import org.grakovne.lissen.domain.CacheStatus
 
+@Keep
 data class CacheState(
     val status: CacheStatus,
     val progress: Double = 0.0,

--- a/app/src/main/java/org/grakovne/lissen/content/cache/entity/CachedBookEntity.kt
+++ b/app/src/main/java/org/grakovne/lissen/content/cache/entity/CachedBookEntity.kt
@@ -1,5 +1,6 @@
 package org.grakovne.lissen.content.cache.entity
 
+import androidx.annotation.Keep
 import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.ForeignKey
@@ -8,6 +9,7 @@ import androidx.room.PrimaryKey
 import androidx.room.Relation
 import java.io.Serializable
 
+@Keep
 data class CachedBookEntity(
     @Embedded val detailedBook: BookEntity,
 
@@ -30,6 +32,7 @@ data class CachedBookEntity(
     val progress: MediaProgressEntity?,
 )
 
+@Keep
 @Entity(tableName = "detailed_books")
 data class BookEntity(
     @PrimaryKey val id: String,
@@ -46,6 +49,7 @@ data class BookEntity(
     val updatedAt: Long,
 ) : Serializable
 
+@Keep
 @Entity(
     tableName = "book_files",
     foreignKeys = [
@@ -67,6 +71,7 @@ data class BookFileEntity(
     val bookId: String,
 ) : Serializable
 
+@Keep
 @Entity(
     tableName = "book_chapters",
     foreignKeys = [
@@ -90,6 +95,7 @@ data class BookChapterEntity(
     val isCached: Boolean,
 ) : Serializable
 
+@Keep
 @Entity(
     tableName = "media_progress",
     foreignKeys = [
@@ -109,6 +115,7 @@ data class MediaProgressEntity(
     val lastUpdate: Long,
 ) : Serializable
 
+@Keep
 data class BookSeriesDto(
     val title: String,
     val sequence: String?,

--- a/app/src/main/java/org/grakovne/lissen/content/cache/entity/CachedLibraryEntity.kt
+++ b/app/src/main/java/org/grakovne/lissen/content/cache/entity/CachedLibraryEntity.kt
@@ -1,10 +1,12 @@
 package org.grakovne.lissen.content.cache.entity
 
+import androidx.annotation.Keep
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import org.grakovne.lissen.channel.common.LibraryType
 import java.io.Serializable
 
+@Keep
 @Entity(
     tableName = "libraries",
 )

--- a/app/src/main/java/org/grakovne/lissen/content/cache/entity/PlaybackProgressEntity.kt
+++ b/app/src/main/java/org/grakovne/lissen/content/cache/entity/PlaybackProgressEntity.kt
@@ -1,8 +1,10 @@
 package org.grakovne.lissen.content.cache.entity
 
+import androidx.annotation.Keep
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
+@Keep
 @Entity(tableName = "playback_progress")
 data class PlaybackProgressEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,

--- a/app/src/main/java/org/grakovne/lissen/domain/Book.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/Book.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.domain
 
+import androidx.annotation.Keep
+
+@Keep
 data class Book(
     val id: String,
     val subtitle: String?,

--- a/app/src/main/java/org/grakovne/lissen/domain/ContentCachingTask.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/ContentCachingTask.kt
@@ -1,7 +1,9 @@
 package org.grakovne.lissen.domain
 
+import androidx.annotation.Keep
 import java.io.Serializable
 
+@Keep
 data class ContentCachingTask(
     val itemId: String,
     val options: DownloadOption,

--- a/app/src/main/java/org/grakovne/lissen/domain/DetailedItem.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/DetailedItem.kt
@@ -1,7 +1,9 @@
 package org.grakovne.lissen.domain
 
+import androidx.annotation.Keep
 import java.io.Serializable
 
+@Keep
 data class DetailedItem(
     val id: String,
     val title: String,
@@ -20,6 +22,7 @@ data class DetailedItem(
     val updatedAt: Long,
 ) : Serializable
 
+@Keep
 data class BookFile(
     val id: String,
     val name: String,
@@ -27,12 +30,14 @@ data class BookFile(
     val mimeType: String,
 ) : Serializable
 
+@Keep
 data class MediaProgress(
     val currentTime: Double,
     val isFinished: Boolean,
     val lastUpdate: Long,
 ) : Serializable
 
+@Keep
 data class PlayingChapter(
     val available: Boolean,
     val podcastEpisodeState: BookChapterState?,
@@ -43,11 +48,13 @@ data class PlayingChapter(
     val id: String,
 ) : Serializable
 
+@Keep
 data class BookSeries(
     val serialNumber: String?,
     val name: String,
 ) : Serializable
 
+@Keep
 enum class BookChapterState {
     FINISHED,
 }

--- a/app/src/main/java/org/grakovne/lissen/domain/DownloadOption.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/DownloadOption.kt
@@ -1,7 +1,9 @@
 package org.grakovne.lissen.domain
 
+import androidx.annotation.Keep
 import java.io.Serializable
 
+@Keep
 sealed interface DownloadOption : Serializable
 
 class NumberItemDownloadOption(val itemsNumber: Int) : DownloadOption

--- a/app/src/main/java/org/grakovne/lissen/domain/Library.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/Library.kt
@@ -1,7 +1,9 @@
 package org.grakovne.lissen.domain
 
+import androidx.annotation.Keep
 import org.grakovne.lissen.channel.common.LibraryType
 
+@Keep
 data class Library(
     val id: String,
     val title: String,

--- a/app/src/main/java/org/grakovne/lissen/domain/PagedItems.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/PagedItems.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.domain
 
+import androidx.annotation.Keep
+
+@Keep
 data class PagedItems<T>(
     val items: List<T>,
     val currentPage: Int,

--- a/app/src/main/java/org/grakovne/lissen/domain/PlaybackProgress.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/PlaybackProgress.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.domain
 
+import androidx.annotation.Keep
+
+@Keep
 data class PlaybackProgress(
     val currentTime: Double,
     val totalTime: Double,

--- a/app/src/main/java/org/grakovne/lissen/domain/PlaybackSession.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/PlaybackSession.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.domain
 
+import androidx.annotation.Keep
+
+@Keep
 data class PlaybackSession(
     val sessionId: String,
     val bookId: String,

--- a/app/src/main/java/org/grakovne/lissen/domain/RecentBook.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/RecentBook.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.domain
 
+import androidx.annotation.Keep
+
+@Keep
 data class RecentBook(
     val id: String,
     val title: String,

--- a/app/src/main/java/org/grakovne/lissen/domain/SeekTime.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/SeekTime.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.domain
 
+import androidx.annotation.Keep
+
+@Keep
 data class SeekTime(
     val rewind: SeekTimeOption,
     val forward: SeekTimeOption,

--- a/app/src/main/java/org/grakovne/lissen/domain/UserAccount.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/UserAccount.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.domain
 
+import androidx.annotation.Keep
+
+@Keep
 data class UserAccount(
     val token: String,
     val username: String,

--- a/app/src/main/java/org/grakovne/lissen/domain/connection/ServerRequestHeader.kt
+++ b/app/src/main/java/org/grakovne/lissen/domain/connection/ServerRequestHeader.kt
@@ -1,7 +1,9 @@
 package org.grakovne.lissen.domain.connection
 
+import androidx.annotation.Keep
 import java.util.UUID
 
+@Keep
 data class ServerRequestHeader(
     val name: String,
     val value: String,

--- a/app/src/main/java/org/grakovne/lissen/ui/screens/settings/composable/CommonSettingsItem.kt
+++ b/app/src/main/java/org/grakovne/lissen/ui/screens/settings/composable/CommonSettingsItem.kt
@@ -1,7 +1,9 @@
 package org.grakovne.lissen.ui.screens.settings.composable
 
+import androidx.annotation.Keep
 import androidx.compose.ui.graphics.vector.ImageVector
 
+@Keep
 data class CommonSettingsItem(
     val id: String,
     val name: String,


### PR DESCRIPTION
Creates debug and release builds for lissen. This reduces the build apk size from ~80 MB to ~8.4 MB . 

- Needed to [add keep to every data class](https://stackoverflow.com/a/63824377/1655478), and a [few extras for gson.](https://stackoverflow.com/questions/76224936/google-gson-preserve-generic-signatures)
- Adds signing config settings. [See here](https://stackoverflow.com/a/43230396/1655478)
- Adds a `debug` build variant, so debug builds have their own app id / title, and can be installed at the same time as release builds.
- Fixes #169