### PR TITLE
Advertise direct-play support for ogg and mka

### DIFF
--- a/app/src/main/java/org/grakovne/lissen/playback/service/MimeTypeProvider.kt
+++ b/app/src/main/java/org/grakovne/lissen/playback/service/MimeTypeProvider.kt
@@ -12,7 +12,9 @@ class MimeTypeProvider {
         "audio/webm",
         "audio/ac3",
         "audio/opus",
+        "audio/ogg",
         "audio/vorbis",
+        "audio/x-matroska",
       )
   }
 }


### PR DESCRIPTION
I noticed that Lissen did not use direct play for my ogg+opus files.

This behaviour was kinda expected, as Lissen does not send a suitable mimetype:

https://github.com/advplyr/audiobookshelf/blob/28404f37b8049638da56ba4bc5b55c78e61c51d2/server/utils/constants.js#L36

At the same time, I checked that mka files work as expected (matroska+aac).

Both of these formats are only containers. ExoPlayer should probably play any OGG file. Not so sure about matroska, as there can be almost any codec inside. But I guess that logic would need to be fixed in audiobookshelf itself first.