### PR TITLE
Fix audiobook progress not caching when app is offline

### DIFF
--- a/app/src/main/kotlin/org/grakovne/lissen/channel/audiobookshelf/common/converter/PlaybackSessionResponseConverter.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/channel/audiobookshelf/common/converter/PlaybackSessionResponseConverter.kt
@@ -2,6 +2,7 @@ package org.grakovne.lissen.channel.audiobookshelf.common.converter
 
 import org.grakovne.lissen.channel.audiobookshelf.common.model.playback.PlaybackSessionResponse
 import org.grakovne.lissen.lib.domain.PlaybackSession
+import org.grakovne.lissen.lib.domain.PlaybackSessionSource
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -10,7 +11,7 @@ class PlaybackSessionResponseConverter
   @Inject
   constructor() {
     fun apply(response: PlaybackSessionResponse): PlaybackSession =
-      PlaybackSession(
+      PlaybackSession.remote(
         sessionId = response.id,
         itemId = response.libraryItemId,
       )

--- a/app/src/main/kotlin/org/grakovne/lissen/content/LissenMediaProvider.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/LissenMediaProvider.kt
@@ -20,7 +20,6 @@ import org.grakovne.lissen.lib.domain.UserAccount
 import org.grakovne.lissen.persistence.preferences.LissenSharedPreferences
 import timber.log.Timber
 import java.io.File
-import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -158,12 +157,7 @@ class LissenMediaProvider
           OperationResult.Success(it)
         },
         onFailure = {
-          OperationResult.Success(
-            PlaybackSession(
-              sessionId = "local-${UUID.randomUUID()}",
-              itemId = itemId,
-            ),
-          )
+          OperationResult.Success(PlaybackSession.local(itemId))
         },
       )
     }

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackSynchronizationService.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackSynchronizationService.kt
@@ -14,6 +14,7 @@ import org.grakovne.lissen.content.LissenMediaProvider
 import org.grakovne.lissen.lib.domain.DetailedItem
 import org.grakovne.lissen.lib.domain.PlaybackProgress
 import org.grakovne.lissen.lib.domain.PlaybackSession
+import org.grakovne.lissen.lib.domain.PlaybackSessionSource
 import org.grakovne.lissen.persistence.preferences.LissenSharedPreferences
 import timber.log.Timber
 import javax.inject.Inject
@@ -109,7 +110,7 @@ class PlaybackSynchronizationService
           if (playbackSession == null ||
             playbackSession?.itemId != currentItem?.id ||
             currentIndex != currentChapterIndex ||
-            playbackSession?.sessionId?.startsWith("local-") == true
+            playbackSession?.sessionSource == PlaybackSessionSource.LOCAL
           ) {
             openPlaybackSession(overallProgress)
             currentChapterIndex = currentIndex

--- a/lib/src/main/kotlin/org/grakovne/lissen/lib/domain/PlaybackSession.kt
+++ b/lib/src/main/kotlin/org/grakovne/lissen/lib/domain/PlaybackSession.kt
@@ -1,9 +1,33 @@
 package org.grakovne.lissen.lib.domain
 
 import androidx.annotation.Keep
+import java.util.UUID
 
+enum class PlaybackSessionSource {
+    LOCAL,
+    REMOTE,
+}
 @Keep
 data class PlaybackSession(
   val sessionId: String,
   val itemId: String,
-)
+  val sessionSource: PlaybackSessionSource,
+) {
+    companion object {
+        fun local(itemId: String): PlaybackSession {
+            return PlaybackSession(
+                sessionId = "local-${UUID.randomUUID()}",
+                itemId = itemId,
+                sessionSource = PlaybackSessionSource.LOCAL,
+            )
+        }
+
+        fun remote(sessionId: String, itemId: String): PlaybackSession {
+            return PlaybackSession(
+                sessionId = sessionId,
+                itemId = itemId,
+                sessionSource = PlaybackSessionSource.REMOTE,
+            )
+        }
+    }
+}


### PR DESCRIPTION
Fix #319. In `PlaybackSynchronizationService.runSync()`, it always hits this block when app is running offline:

```kotlin
if (playbackSession == null || playbackSession?.itemId != currentItem?.id || currentIndex != currentChapterIndex) {
    openPlaybackSession(overallProgress)
    currentChapterIndex = currentIndex
}
```

`openPlaybackSession()` fails silently, skipping `playbackSession.requestSync()` and cached progress updates.

I added a `localCacheRepository` call to ensure local progress updates regardless of online/offline status. Online sync is unchanged.