### PR TITLE
Return short silence when no audio files for a chapter

### DIFF
--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactory.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactory.kt
@@ -10,6 +10,7 @@ import androidx.media3.exoplayer.source.ClippingMediaSource
 import androidx.media3.exoplayer.source.ConcatenatingMediaSource2
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.SilenceMediaSource
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 import kotlinx.parcelize.Parcelize
 import org.grakovne.lissen.playback.service.PlaybackService.Companion.FILE_SEGMENTS
@@ -82,19 +83,30 @@ class LissenMediaSourceFactory(
     return MediaId.fromString(mediaItem.mediaId)?.let { (bookId, chapterId) ->
       mediaItem.requestMetadata.extras?.let { extras ->
         BundleCompat.getParcelableArrayList(extras, FILE_SEGMENTS, FileClip::class.java)?.let { segments ->
-          segments.singleOrNull()?.toMediaSource(bookId, mediaItem.mediaMetadata)
-            ?: ConcatenatingMediaSource2
-              .Builder()
-              .apply {
-                segments.forEach {
-                  add(it.toMediaSource(bookId), ((it.clipEnd - it.clipStart) * 1000).toLong())
-                }
-              }.setMediaItem(
-                MediaItem
-                  .Builder()
-                  .setMediaMetadata(mediaItem.mediaMetadata)
-                  .build(),
-              ).build()
+          when (segments.size) {
+            0 -> {
+              SilenceMediaSource(1L)
+            }
+
+            1 -> {
+              segments.first().toMediaSource(bookId, mediaItem.mediaMetadata)
+            }
+
+            else -> {
+              ConcatenatingMediaSource2
+                .Builder()
+                .apply {
+                  segments.forEach {
+                    add(it.toMediaSource(bookId), ((it.clipEnd - it.clipStart) * 1000).toLong())
+                  }
+                }.setMediaItem(
+                  MediaItem
+                    .Builder()
+                    .setMediaMetadata(mediaItem.mediaMetadata)
+                    .build(),
+                ).build()
+            }
+          }
         }
       }
     } ?: mediaSourceFactory.createMediaSource(mediaItem)


### PR DESCRIPTION
Fixes #367.

This should be considered a stopgap measure. We need to figure out what should happen if we have a chapter with no audio: do we still keep it in the timeline with a placeholder source (like in this PR) or maybe drop it entirely.

I think it can happen if chapters metadata are wrong and audio files are missing. I don't remember if I've left this logic in, but it can also happen if the whole chapter is unusually short, like 200ms. At some point I was removing very short file fragments from the chapter timeline. If the chapter is short, then nothing would be left.

I have instrumented test for this case (failed with exactly the same stacktrace), i'll add it to the longer PR, as this branch has no instrumented tests setup yet.