### PR TITLE
Fix API calls failing when server is hosted at a subpath

### DIFF
--- a/app/src/main/kotlin/org/grakovne/lissen/channel/audiobookshelf/common/client/AudiobookshelfApiClient.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/channel/audiobookshelf/common/client/AudiobookshelfApiClient.kt
@@ -33,38 +33,38 @@ import retrofit2.http.Query
 import retrofit2.http.Streaming
 
 interface AudiobookshelfApiClient {
-  @GET("/api/libraries")
+  @GET("api/libraries")
   suspend fun fetchLibraries(): Response<LibraryResponse>
 
-  @GET("/api/libraries/{libraryId}/personalized")
+  @GET("api/libraries/{libraryId}/personalized")
   suspend fun fetchPersonalizedFeed(
     @Path("libraryId") libraryId: String,
   ): Response<List<PersonalizedFeedResponse>>
 
-  @GET("/api/me/progress/{itemId}")
+  @GET("api/me/progress/{itemId}")
   suspend fun fetchLibraryItemProgress(
     @Path("itemId") itemId: String,
   ): Response<MediaProgressResponse>
 
-  @POST("/api/authorize")
+  @POST("api/authorize")
   suspend fun fetchConnectionInfo(): Response<ConnectionInfoResponse>
 
-  @GET("/api/me")
+  @GET("api/me")
   suspend fun fetchBookmarks(): Response<BookmarksResponse>
 
-  @POST("/api/me/item/{libraryItemId}/bookmark")
+  @POST("api/me/item/{libraryItemId}/bookmark")
   suspend fun createBookmarks(
     @Path("libraryItemId") libraryItemId: String,
     @Body request: BookmarkRequest,
   ): Response<BookmarksItemResponse>
 
-  @DELETE("/api/me/item/{libraryItemId}/bookmark/{totalTime}")
+  @DELETE("api/me/item/{libraryItemId}/bookmark/{totalTime}")
   suspend fun dropBookmarks(
     @Path("libraryItemId") libraryItemId: String,
     @Path("totalTime") totalTime: Int,
   ): Response<Unit>
 
-  @GET("/api/me")
+  @GET("api/me")
   suspend fun fetchUserInfo(): Response<UserResponse>
 
   @GET("api/libraries/{libraryId}/items")
@@ -102,35 +102,35 @@ interface AudiobookshelfApiClient {
     @Query("limit") limit: Int,
   ): Response<PodcastSearchResponse>
 
-  @GET("/api/items/{itemId}")
+  @GET("api/items/{itemId}")
   suspend fun fetchLibraryItem(
     @Path("itemId") itemId: String,
   ): Response<BookResponse>
 
-  @GET("/api/items/{itemId}")
+  @GET("api/items/{itemId}")
   suspend fun fetchPodcastEpisode(
     @Path("itemId") itemId: String,
   ): Response<PodcastResponse>
 
-  @GET("/api/authors/{authorId}?include=items")
+  @GET("api/authors/{authorId}?include=items")
   suspend fun fetchAuthorLibraryItems(
     @Path("authorId") authorId: String,
   ): Response<AuthorItemsResponse>
 
-  @POST("/api/session/{itemId}/sync")
+  @POST("api/session/{itemId}/sync")
   suspend fun publishLibraryItemProgress(
     @Path("itemId") itemId: String,
     @Body syncProgressRequest: ProgressSyncRequest,
   ): Response<Unit>
 
-  @POST("/api/items/{itemId}/play/{episodeId}")
+  @POST("api/items/{itemId}/play/{episodeId}")
   suspend fun startPodcastPlayback(
     @Path("itemId") itemId: String,
     @Path("episodeId") episodeId: String,
     @Body syncProgressRequest: PlaybackStartRequest,
   ): Response<PlaybackSessionResponse>
 
-  @POST("/api/items/{itemId}/play")
+  @POST("api/items/{itemId}/play")
   suspend fun startLibraryPlayback(
     @Path("itemId") itemId: String,
     @Body syncProgressRequest: PlaybackStartRequest,
@@ -148,13 +148,13 @@ interface AudiobookshelfApiClient {
     @Header("x-refresh-token") refreshToken: String,
   ): Response<LoggedUserResponse>
 
-  @GET("/api/items/{itemId}/cover?raw=1")
+  @GET("api/items/{itemId}/cover?raw=1")
   @Streaming
   suspend fun getItemCover(
     @Path("itemId") itemId: String,
   ): Response<ResponseBody>
 
-  @GET("/api/items/{itemId}/cover")
+  @GET("api/items/{itemId}/cover")
   @Streaming
   suspend fun getItemCover(
     @Path("itemId") itemId: String,


### PR DESCRIPTION
## Summary

- Removes leading slashes from all Retrofit `@GET`/`@POST`/`@DELETE` endpoint annotations in `AudiobookshelfApiClient`
- This fixes API calls when Audiobookshelf is hosted behind a reverse proxy at a subpath (e.g., `https://example.com/audiobookshelf/`)

## Problem

In Retrofit, endpoint paths with a leading slash (e.g., `@GET("/api/libraries")`) are treated as **absolute** — they resolve against the domain root, discarding any path component from the base URL. When the base URL includes a subpath like `https://example.com/audiobookshelf/`, the request goes to `https://example.com/api/libraries` instead of `https://example.com/audiobookshelf/api/libraries`, resulting in a 404.

Some endpoints already used relative paths (no leading slash), but 16 endpoints still had leading slashes. This change makes all endpoints consistent and subpath-compatible.

## Test plan

- [ ] Verify library listing works when Audiobookshelf is hosted at a subpath (e.g., `/audiobookshelf/`)
- [ ] Verify library listing still works when Audiobookshelf is hosted at the domain root
- [ ] Verify login, playback, bookmarks, and cover art fetching all work in both configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)