### PR TITLE
Support HTTPS:// and HTTP:// urls

### DIFF
--- a/lib/src/main/kotlin/org/grakovne/lissen/lib/domain/FixScheme.kt
+++ b/lib/src/main/kotlin/org/grakovne/lissen/lib/domain/FixScheme.kt
@@ -5,7 +5,7 @@ private const val HTTPS_SCHEME = "https://"
 
 fun String.fixUriScheme(): String {
   val normalized = when {
-    startsWith(HTTP_SCHEME) || startsWith(HTTPS_SCHEME) -> this
+    startsWith(HTTP_SCHEME, true) || startsWith(HTTPS_SCHEME, true) -> this
     else -> HTTP_SCHEME + this
   }
   


### PR DESCRIPTION
Google keyboard autocorrect sometimes likes to capitalize the url schema. So just ignore case when checking if its prefixed

(a better longer term fix might be to disable auto correct on the host input field?)

fixes #382