### PR TITLE
Feature/391 Add per-book custom intro/outro auto-skip for chapters

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,7 +71,7 @@ android {
           enableV2Signing = true
         }
       }
-    }s
+    }
   }
 
   

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,7 +71,7 @@ android {
           enableV2Signing = true
         }
       }
-    }
+    }s
   }
 
   

--- a/app/src/main/kotlin/org/grakovne/lissen/persistence/preferences/LissenSharedPreferences.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/persistence/preferences/LissenSharedPreferences.kt
@@ -17,6 +17,7 @@ import org.grakovne.lissen.common.LibraryOrderingConfiguration
 import org.grakovne.lissen.common.NetworkTypeAutoCache
 import org.grakovne.lissen.common.PlaybackVolumeBoost
 import org.grakovne.lissen.common.moshi
+import org.grakovne.lissen.lib.domain.ChapterSkipConfig
 import org.grakovne.lissen.lib.domain.DetailedItem
 import org.grakovne.lissen.lib.domain.DownloadOption
 import org.grakovne.lissen.lib.domain.Library
@@ -486,6 +487,31 @@ class LissenSharedPreferences
         putBoolean(KEY_HIDE_COMPLETED, value)
       }
 
+    fun saveChapterSkipConfig(
+      bookId: String,
+      config: ChapterSkipConfig,
+    ) {
+      val adapter = moshi.adapter(ChapterSkipConfig::class.java)
+      val json = adapter.toJson(config)
+      sharedPreferences.edit {
+        putString("${KEY_CHAPTER_SKIP_PREFIX}$bookId", json)
+      }
+    }
+
+    fun getChapterSkipConfig(bookId: String): ChapterSkipConfig {
+      val json = sharedPreferences.getString("${KEY_CHAPTER_SKIP_PREFIX}$bookId", null)
+      return when (json) {
+        null -> {
+          ChapterSkipConfig()
+        }
+
+        else -> {
+          val adapter = moshi.adapter(ChapterSkipConfig::class.java)
+          adapter.fromJson(json) ?: ChapterSkipConfig()
+        }
+      }
+    }
+
     companion object {
       private const val KEY_ALIAS = "secure_key_alias"
       private const val KEY_HOST = "host"
@@ -515,6 +541,7 @@ class LissenSharedPreferences
       private const val KEY_PREFERRED_LIBRARY_ORDERING = "preferred_library_ordering"
       private const val KEY_SOFTWARE_CODECS = "software_codecs"
       private const val KEY_HIDE_COMPLETED = "hide_completed"
+      private const val KEY_CHAPTER_SKIP_PREFIX = "chapter_skip_"
 
       private const val KEY_CUSTOM_HEADERS = "custom_headers"
       private const val KEY_BYPASS_SSL = "bypass_ssl"

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.grakovne.lissen.content.LissenMediaProvider
 import org.grakovne.lissen.lib.domain.Bookmark
+import org.grakovne.lissen.lib.domain.ChapterSkipConfig
 import org.grakovne.lissen.lib.domain.CurrentEpisodeTimerOption
 import org.grakovne.lissen.lib.domain.DetailedItem
 import org.grakovne.lissen.lib.domain.DetailedItem.Companion.same
@@ -94,6 +95,13 @@ class MediaRepository
 
     private val _playbackSpeed = MutableLiveData(preferences.getPlaybackSpeed())
     val playbackSpeed: LiveData<Float> = _playbackSpeed
+
+    private val _chapterSkipConfig = MutableLiveData(ChapterSkipConfig())
+    val chapterSkipConfig: LiveData<ChapterSkipConfig> = _chapterSkipConfig
+
+    private var _lastSkippedIntroChapterIndex = -1
+    private var _lastSkippedOutroChapterIndex = -1
+    private var _userSeekedManually = false
 
     private val _currentChapterIndex =
       MediatorLiveData<Int>().apply {
@@ -294,6 +302,7 @@ class MediaRepository
     }
 
     fun setChapterPosition(chapterPosition: Double) {
+      _userSeekedManually = true
       val book = playingBook.value ?: return
       val overallPosition = totalPosition.value ?: return
 
@@ -377,6 +386,7 @@ class MediaRepository
       val currentIndex = calculateChapterIndex(book, overallPosition)
 
       val nextChapterIndex = currentIndex + 1
+      _userSeekedManually = false
       setChapter(nextChapterIndex)
     }
 
@@ -449,6 +459,11 @@ class MediaRepository
 
         _playingBook.postValue(book)
         preferences.savePlayingItem(book)
+
+        _chapterSkipConfig.postValue(preferences.getChapterSkipConfig(book.id))
+        _lastSkippedIntroChapterIndex = -1
+        _lastSkippedOutroChapterIndex = -1
+        _userSeekedManually = false
 
         val intent =
           Intent(context, PlaybackService::class.java).apply {
@@ -562,15 +577,58 @@ class MediaRepository
       val trackIndex = calculateChapterIndex(book, totalPosition)
       val trackPosition = calculateChapterPosition(book, totalPosition)
 
+      val previousIndex = _currentChapterIndex.value ?: -1
+
       _currentChapterIndex.postValue(trackIndex)
       _currentChapterPosition.postValue(trackPosition)
-      _currentChapterDuration.postValue(
+
+      val chapterDuration =
         book
           .chapters
           .getOrNull(trackIndex)
           ?.duration
-          ?: 0.0,
-      )
+          ?: 0.0
+
+      _currentChapterDuration.postValue(chapterDuration)
+
+      val skipConfig = _chapterSkipConfig.value ?: return
+      if (!skipConfig.enabled) return
+      if (_userSeekedManually) {
+        if (trackIndex != previousIndex) {
+          _userSeekedManually = false
+        } else {
+          return
+        }
+      }
+
+      // Intro skip: when entering a new chapter
+      if (skipConfig.introSeconds > 0 &&
+        trackIndex != _lastSkippedIntroChapterIndex &&
+        trackIndex != previousIndex &&
+        previousIndex >= 0
+      ) {
+        val introTarget = skipConfig.introSeconds.toDouble()
+        if (introTarget < chapterDuration) {
+          _lastSkippedIntroChapterIndex = trackIndex
+          val chapterStart = book.chapters[trackIndex].start
+          seekTo(chapterStart + introTarget)
+          return
+        }
+      }
+
+      // Outro skip: when approaching chapter end (not last chapter)
+      if (skipConfig.outroSeconds > 0 &&
+        trackIndex != _lastSkippedOutroChapterIndex &&
+        trackIndex < book.chapters.size - 1
+      ) {
+        val outroThreshold = skipConfig.outroSeconds.toDouble()
+        val remaining = chapterDuration - trackPosition
+        if (remaining in 0.0..outroThreshold) {
+          _lastSkippedOutroChapterIndex = trackIndex
+          nextTrack()
+          return
+        }
+      }
     }
 
     suspend fun createBookmark() {
@@ -622,6 +680,14 @@ class MediaRepository
           .isAtMost(Lifecycle.State.STARTED)
 
       private fun Lifecycle.State.isAtMost(state: Lifecycle.State) = this <= state
+    }
+
+    fun updateChapterSkipConfig(
+      bookId: String,
+      config: ChapterSkipConfig,
+    ) {
+      preferences.saveChapterSkipConfig(bookId, config)
+      _chapterSkipConfig.postValue(config)
     }
   }
 

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/ChapterSkipComposable.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/ChapterSkipComposable.kt
@@ -1,0 +1,288 @@
+package org.grakovne.lissen.ui.screens.player.composable
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.MyLocation
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.MaterialTheme.typography
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.grakovne.lissen.R
+import org.grakovne.lissen.common.withHaptic
+import org.grakovne.lissen.lib.domain.ChapterSkipConfig
+
+private val PRESET_SECONDS = listOf(5, 10, 15, 30)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChapterSkipComposable(
+  config: ChapterSkipConfig,
+  currentChapterPosition: Double,
+  currentChapterDuration: Double,
+  onConfigChanged: (ChapterSkipConfig) -> Unit,
+  onDismissRequest: () -> Unit,
+) {
+  val view = LocalView.current
+
+  ModalBottomSheet(
+    containerColor = colorScheme.background,
+    onDismissRequest = onDismissRequest,
+    content = {
+      Column(
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .padding(bottom = 24.dp)
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        Text(
+          text = stringResource(R.string.chapter_skip_title),
+          style = typography.bodyLarge,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Enable/Disable toggle
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+          Text(
+            text = stringResource(R.string.chapter_skip_enabled),
+            style = typography.bodyMedium,
+          )
+          Switch(
+            checked = config.enabled,
+            onCheckedChange = { enabled ->
+              withHaptic(view) {
+                onConfigChanged(config.copy(enabled = enabled))
+              }
+            },
+          )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+        HorizontalDivider()
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Intro Skip Section
+        SkipSection(
+          title = stringResource(R.string.chapter_skip_intro),
+          currentSeconds = config.introSeconds,
+          onSecondsChanged = { seconds ->
+            withHaptic(view) {
+              onConfigChanged(config.copy(introSeconds = seconds))
+            }
+          },
+          onSetFromPosition = {
+            withHaptic(view) {
+              val seconds = currentChapterPosition.toInt().coerceAtLeast(0)
+              onConfigChanged(config.copy(introSeconds = seconds))
+            }
+          },
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+        HorizontalDivider()
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Outro Skip Section
+        SkipSection(
+          title = stringResource(R.string.chapter_skip_outro),
+          currentSeconds = config.outroSeconds,
+          onSecondsChanged = { seconds ->
+            withHaptic(view) {
+              onConfigChanged(config.copy(outroSeconds = seconds))
+            }
+          },
+          onSetFromPosition = {
+            withHaptic(view) {
+              val remaining = (currentChapterDuration - currentChapterPosition).toInt().coerceAtLeast(0)
+              onConfigChanged(config.copy(outroSeconds = remaining))
+            }
+          },
+        )
+      }
+    },
+  )
+}
+
+@Composable
+private fun SkipSection(
+  title: String,
+  currentSeconds: Int,
+  onSecondsChanged: (Int) -> Unit,
+  onSetFromPosition: () -> Unit,
+) {
+  var manualInput by remember(currentSeconds) { mutableStateOf("") }
+
+  Column(
+    modifier = Modifier.fillMaxWidth(),
+  ) {
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+      Text(
+        text = title,
+        style = typography.titleSmall,
+        fontWeight = FontWeight.Bold,
+      )
+      Text(
+        text =
+          if (currentSeconds > 0) {
+            stringResource(R.string.chapter_skip_current_value, currentSeconds)
+          } else {
+            stringResource(R.string.chapter_skip_disabled)
+          },
+        style = typography.bodySmall,
+        color = colorScheme.onSurfaceVariant,
+      )
+    }
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    // Preset buttons
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+      PRESET_SECONDS.forEach { seconds ->
+        FilledTonalButton(
+          onClick = {
+            onSecondsChanged(if (currentSeconds == seconds) 0 else seconds)
+          },
+          modifier = Modifier.size(52.dp),
+          shape = CircleShape,
+          colors =
+            ButtonDefaults.filledTonalButtonColors(
+              containerColor =
+                if (currentSeconds == seconds) {
+                  colorScheme.primary
+                } else {
+                  colorScheme.surfaceContainer
+                },
+              contentColor =
+                if (currentSeconds == seconds) {
+                  colorScheme.onPrimary
+                } else {
+                  colorScheme.onSurfaceVariant
+                },
+            ),
+          contentPadding = PaddingValues(0.dp),
+        ) {
+          Text(
+            text = "${seconds}s",
+            style =
+              if (currentSeconds == seconds) {
+                typography.labelMedium.copy(fontWeight = FontWeight.Bold)
+              } else {
+                typography.labelMedium
+              },
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+          )
+        }
+      }
+    }
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    // Set from current position button
+    TextButton(
+      onClick = onSetFromPosition,
+      modifier = Modifier.fillMaxWidth(),
+    ) {
+      Icon(
+        imageVector = Icons.Outlined.MyLocation,
+        contentDescription = null,
+        modifier = Modifier.size(16.dp),
+      )
+      Spacer(modifier = Modifier.width(6.dp))
+      Text(
+        text = stringResource(R.string.chapter_skip_set_from_position),
+        style = typography.bodySmall,
+      )
+    }
+
+    // Manual input
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.Center,
+    ) {
+      OutlinedTextField(
+        value = manualInput,
+        onValueChange = { value ->
+          manualInput = value.filter { it.isDigit() }
+        },
+        label = {
+          Text(
+            text = stringResource(R.string.chapter_skip_manual_input),
+            style = typography.bodySmall,
+          )
+        },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        modifier =
+          Modifier
+            .weight(1f)
+            .height(56.dp),
+        shape = RoundedCornerShape(12.dp),
+        singleLine = true,
+        textStyle = typography.bodyMedium,
+      )
+      Spacer(modifier = Modifier.width(8.dp))
+      FilledTonalButton(
+        onClick = {
+          val seconds = manualInput.toIntOrNull() ?: 0
+          onSecondsChanged(seconds.coerceIn(0, 3600))
+          manualInput = ""
+        },
+        enabled = manualInput.isNotBlank(),
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier.height(56.dp),
+      ) {
+        Text(
+          text = stringResource(android.R.string.ok),
+          style = typography.labelMedium,
+        )
+      }
+    }
+  }
+}

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/NavigationBarComposable.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/NavigationBarComposable.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.outlined.CloudDownload
+import androidx.compose.material.icons.outlined.ContentCut
 import androidx.compose.material.icons.outlined.SlowMotionVideo
 import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.material3.CircularProgressIndicator
@@ -39,6 +40,7 @@ import kotlinx.coroutines.launch
 import org.grakovne.lissen.R
 import org.grakovne.lissen.content.cache.persistent.CacheState
 import org.grakovne.lissen.lib.domain.CacheStatus
+import org.grakovne.lissen.lib.domain.ChapterSkipConfig
 import org.grakovne.lissen.lib.domain.CurrentEpisodeTimerOption
 import org.grakovne.lissen.lib.domain.DetailedItem
 import org.grakovne.lissen.lib.domain.DurationTimerOption
@@ -70,6 +72,11 @@ fun NavigationBarComposable(
   var playbackSpeedExpanded by remember { mutableStateOf(false) }
   var timerExpanded by remember { mutableStateOf(false) }
   var downloadsExpanded by remember { mutableStateOf(false) }
+  var chapterSkipExpanded by remember { mutableStateOf(false) }
+
+  val chapterSkipConfig by playerViewModel.chapterSkipConfig.observeAsState(ChapterSkipConfig())
+  val currentChapterPosition by playerViewModel.currentChapterPosition.observeAsState(0.0)
+  val currentChapterDuration by playerViewModel.currentChapterDuration.observeAsState(0.0)
 
   val scope = rememberCoroutineScope()
 
@@ -173,6 +180,33 @@ fun NavigationBarComposable(
       )
 
       NavigationBarItem(
+        enabled = hasEpisodes,
+        icon = {
+          Icon(
+            Icons.Outlined.ContentCut,
+            contentDescription = stringResource(R.string.player_screen_chapter_skip_navigation),
+            modifier = Modifier.size(iconSize),
+            tint = if (chapterSkipConfig.enabled) colorScheme.primary else LocalContentColor.current,
+          )
+        },
+        label = {
+          Text(
+            text = stringResource(R.string.player_screen_chapter_skip_navigation),
+            style = labelStyle,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+          )
+        },
+        selected = false,
+        onClick = { chapterSkipExpanded = true },
+        colors =
+          NavigationBarItemDefaults.colors(
+            selectedIconColor = colorScheme.primary,
+            indicatorColor = colorScheme.surfaceContainer,
+          ),
+      )
+
+      NavigationBarItem(
         icon = {
           Icon(
             when (timerOption) {
@@ -232,6 +266,16 @@ fun NavigationBarComposable(
           currentOption = timerOption,
           onOptionSelected = { playerViewModel.setTimer(it) },
           onDismissRequest = { timerExpanded = false },
+        )
+      }
+
+      if (chapterSkipExpanded) {
+        ChapterSkipComposable(
+          config = chapterSkipConfig,
+          currentChapterPosition = currentChapterPosition,
+          currentChapterDuration = currentChapterDuration,
+          onConfigChanged = { playerViewModel.updateChapterSkipConfig(it) },
+          onDismissRequest = { chapterSkipExpanded = false },
         )
       }
 

--- a/app/src/main/kotlin/org/grakovne/lissen/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/viewmodel/PlayerViewModel.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.util.UnstableApi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import org.grakovne.lissen.lib.domain.Bookmark
+import org.grakovne.lissen.lib.domain.ChapterSkipConfig
 import org.grakovne.lissen.lib.domain.DetailedItem
 import org.grakovne.lissen.lib.domain.PlayingChapter
 import org.grakovne.lissen.lib.domain.TimerOption
@@ -49,6 +50,8 @@ class PlayerViewModel
     val searchToken: LiveData<String> = _searchToken
 
     val isPlaying: LiveData<Boolean> = mediaRepository.isPlaying
+
+    val chapterSkipConfig: LiveData<ChapterSkipConfig> = mediaRepository.chapterSkipConfig
 
     val bookmarks = mediaRepository.bookmarks
 
@@ -145,6 +148,11 @@ class PlayerViewModel
     fun previousTrack() = mediaRepository.previousTrack()
 
     fun togglePlayPause() = mediaRepository.togglePlayPause()
+
+    fun updateChapterSkipConfig(config: ChapterSkipConfig) {
+      val bookId = book.value?.id ?: return
+      mediaRepository.updateChapterSkipConfig(bookId, config)
+    }
 
     fun prepareAndPlay() {
       val playingBook = preferences.getPlayingItem() ?: return

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -179,4 +179,13 @@
     <string name="connection_settings_description">管理服务器地址、代理及 SSL 设置</string>
     <string name="connection_settings_title">连接偏好设置</string>
     <string name="disconnect_from_server_title">断开服务器连接</string>
+    <string name="player_screen_chapter_skip_navigation">跳过</string>
+    <string name="chapter_skip_title">章节跳过设置</string>
+    <string name="chapter_skip_enabled">启用自动跳过</string>
+    <string name="chapter_skip_intro">片头跳过</string>
+    <string name="chapter_skip_outro">片尾跳过</string>
+    <string name="chapter_skip_current_value">当前：%d秒</string>
+    <string name="chapter_skip_set_from_position">从当前位置设置</string>
+    <string name="chapter_skip_manual_input">自定义（秒）</string>
+    <string name="chapter_skip_disabled">已禁用</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,4 +179,13 @@
     <string name="connection_settings_title">Connection preferences</string>
     <string name="connection_settings_description">Control server address, proxy, and SSL settings</string>
     <string name="disconnect_from_server_title">Disconnect from the server</string>
+    <string name="player_screen_chapter_skip_navigation">Skip</string>
+    <string name="chapter_skip_title">Chapter Skip</string>
+    <string name="chapter_skip_enabled">Enable auto-skip</string>
+    <string name="chapter_skip_intro">Intro Skip</string>
+    <string name="chapter_skip_outro">Outro Skip</string>
+    <string name="chapter_skip_current_value">Current: %ds</string>
+    <string name="chapter_skip_set_from_position">Set from current position</string>
+    <string name="chapter_skip_manual_input">Custom (seconds)</string>
+    <string name="chapter_skip_disabled">Disabled</string>
 </resources>

--- a/lib/src/main/kotlin/org/grakovne/lissen/lib/domain/ChapterSkipConfig.kt
+++ b/lib/src/main/kotlin/org/grakovne/lissen/lib/domain/ChapterSkipConfig.kt
@@ -1,0 +1,12 @@
+package org.grakovne.lissen.lib.domain
+
+import androidx.annotation.Keep
+import com.squareup.moshi.JsonClass
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class ChapterSkipConfig(
+  val enabled: Boolean = false,
+  val introSeconds: Int = 0,
+  val outroSeconds: Int = 0,
+)


### PR DESCRIPTION
Implement per-book custom intro and outro auto-skip support for chapters. Users can now set individual skip ranges for each book, which will be automatically applied during chapter playback.