### PR TITLE
[codex] improve player queue gestures

### DIFF
--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/PlayerScreen.kt
@@ -3,6 +3,7 @@ package org.grakovne.lissen.ui.screens.player
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
@@ -10,6 +11,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -41,7 +43,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -69,6 +74,7 @@ import org.grakovne.lissen.viewmodel.CachingModelView
 import org.grakovne.lissen.viewmodel.LibraryViewModel
 import org.grakovne.lissen.viewmodel.PlayerViewModel
 import org.grakovne.lissen.viewmodel.SettingsViewModel
+import kotlin.math.abs
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -93,9 +99,20 @@ fun PlayerScreen(
   val isPlaybackReady by playerViewModel.isPlaybackReady.observeAsState(false)
   val playingQueueExpanded by playerViewModel.playingQueueExpanded.observeAsState(false)
   val searchRequested by playerViewModel.searchRequested.observeAsState(false)
+  val density = LocalDensity.current
 
   var itemDetailsSelected by remember { mutableStateOf(false) }
   var bookmarksSelected by remember { mutableStateOf(false) }
+  var playerDragOffset by remember { mutableStateOf(0f) }
+  var playerSwipeHandled by remember { mutableStateOf(false) }
+
+  val playerSwipeThreshold = with(density) { 48.dp.toPx() }
+  val maxPlayerDrag = with(density) { 64.dp.toPx() }
+  val animatedPlayerDragOffset by animateFloatAsState(
+    targetValue = playerDragOffset,
+    animationSpec = tween(durationMillis = 180),
+    label = "player_screen_vertical_drag",
+  )
 
   val screenTitle =
     when (playingQueueExpanded) {
@@ -108,6 +125,32 @@ fun PlayerScreen(
       searchRequested -> playerViewModel.dismissSearch()
       playingQueueExpanded -> playerViewModel.collapsePlayingQueue()
       else -> navController.showLibrary(clearHistory = true)
+    }
+  }
+
+  fun handlePlayerVerticalSwipe() {
+    if (playerSwipeHandled) {
+      playerDragOffset = 0f
+      return
+    }
+
+    val hasChapters = playingBook?.chapters?.isNotEmpty() == true
+    val dragOffset = playerDragOffset
+
+    playerDragOffset = 0f
+
+    when {
+      abs(dragOffset) < playerSwipeThreshold -> {
+        Unit
+      }
+
+      dragOffset < 0 && hasChapters && isPlaybackReady && !playingQueueExpanded -> {
+        playerViewModel.expandPlayingQueue()
+      }
+
+      dragOffset > 0 -> {
+        stepBack()
+      }
     }
   }
 
@@ -251,63 +294,104 @@ fun PlayerScreen(
             .padding(innerPadding),
         horizontalAlignment = Alignment.CenterHorizontally,
       ) {
-        AnimatedVisibility(
-          visible = playingQueueExpanded.not(),
-          enter = expandVertically(animationSpec = tween(400)),
-          exit = shrinkVertically(animationSpec = tween(400)),
+        Column(
+          modifier =
+            Modifier
+              .graphicsLayer {
+                translationY = animatedPlayerDragOffset
+              }.pointerInput(playingQueueExpanded, isPlaybackReady, playingBook?.id) {
+                detectVerticalDragGestures(
+                  onVerticalDrag = { change, dragAmount ->
+                    if (playingQueueExpanded) return@detectVerticalDragGestures
+                    if (playerSwipeHandled) return@detectVerticalDragGestures
+
+                    change.consume()
+                    playerDragOffset = (playerDragOffset + dragAmount).coerceIn(-maxPlayerDrag, maxPlayerDrag)
+
+                    if (
+                      playerDragOffset <= -playerSwipeThreshold &&
+                      playingBook?.chapters?.isNotEmpty() == true &&
+                      isPlaybackReady
+                    ) {
+                      playerSwipeHandled = true
+                      playerViewModel.expandPlayingQueue()
+                      playerDragOffset = 0f
+                    } else if (playerDragOffset >= playerSwipeThreshold) {
+                      playerSwipeHandled = true
+                      stepBack()
+                      playerDragOffset = 0f
+                    }
+                  },
+                  onDragEnd = {
+                    handlePlayerVerticalSwipe()
+                    playerSwipeHandled = false
+                  },
+                  onDragCancel = {
+                    playerDragOffset = 0f
+                    playerSwipeHandled = false
+                  },
+                )
+              },
+          horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-          Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
+          AnimatedVisibility(
+            visible = playingQueueExpanded.not(),
+            enter = expandVertically(animationSpec = tween(400)),
+            exit = shrinkVertically(animationSpec = tween(400)),
           ) {
-            if (!isPlaybackReady) {
-              TrackDetailsPlaceholderComposable(bookTitle, bookSubtitle)
-            } else {
-              TrackDetailsComposable(
-                viewModel = playerViewModel,
-                imageLoader = imageLoader,
+            Column(
+              horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+              if (!isPlaybackReady) {
+                TrackDetailsPlaceholderComposable(bookTitle, bookSubtitle)
+              } else {
+                TrackDetailsComposable(
+                  viewModel = playerViewModel,
+                  imageLoader = imageLoader,
+                  libraryViewModel = libraryViewModel,
+                )
+              }
+
+              if (!isPlaybackReady) {
+                TrackControlPlaceholderComposable(
+                  modifier = Modifier,
+                  settingsViewModel = settingsViewModel,
+                )
+              } else {
+                TrackControlComposable(
+                  viewModel = playerViewModel,
+                  modifier = Modifier,
+                  settingsViewModel = settingsViewModel,
+                )
+              }
+            }
+          }
+
+          Spacer(modifier = Modifier.height(6.dp))
+
+          when {
+            isPlaybackReady.not() -> {
+              PlayingQueuePlaceholderComposable(
                 libraryViewModel = libraryViewModel,
+                modifier = Modifier,
               )
             }
 
-            if (!isPlaybackReady) {
-              TrackControlPlaceholderComposable(
+            playingBook?.chapters.isNullOrEmpty() -> {
+              PlayingQueueFallbackComposable(
+                libraryViewModel = libraryViewModel,
                 modifier = Modifier,
-                settingsViewModel = settingsViewModel,
               )
-            } else {
-              TrackControlComposable(
+            }
+
+            else -> {
+              PlayingQueueComposable(
+                libraryViewModel = libraryViewModel,
+                cachingModelView = cachingModelView,
                 viewModel = playerViewModel,
                 modifier = Modifier,
-                settingsViewModel = settingsViewModel,
               )
             }
-          }
-        }
-
-        Spacer(modifier = Modifier.height(6.dp))
-
-        when {
-          isPlaybackReady.not() -> {
-            PlayingQueuePlaceholderComposable(
-              libraryViewModel = libraryViewModel,
-              modifier = Modifier,
-            )
-          }
-
-          playingBook?.chapters.isNullOrEmpty() -> {
-            PlayingQueueFallbackComposable(
-              libraryViewModel = libraryViewModel,
-              modifier = Modifier,
-            )
-          }
-
-          else -> {
-            PlayingQueueComposable(
-              libraryViewModel = libraryViewModel,
-              cachingModelView = cachingModelView,
-              viewModel = playerViewModel,
-              modifier = Modifier,
-            )
           }
         }
       }

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/PlayingQueueComposable.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/PlayingQueueComposable.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Box
@@ -14,8 +16,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -44,6 +48,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
@@ -52,6 +57,8 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
@@ -114,7 +121,7 @@ fun PlayingQueueComposable(
     remember { ViewConfiguration.get(context).scaledMinimumFlingVelocity.toFloat() * 2 }
 
   val collapseFlingThreshold =
-    remember { ViewConfiguration.get(context).scaledMaximumFlingVelocity.toFloat() * 0.3 }
+    remember { ViewConfiguration.get(context).scaledMinimumFlingVelocity.toFloat() * 2 }
 
   val listState = rememberLazyListState()
 
@@ -222,6 +229,31 @@ fun PlayingQueueComposable(
             }
           }.padding(horizontal = 16.dp),
     ) {
+      Box(
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .clickable { viewModel.togglePlayingQueue() }
+            .semantics {
+              contentDescription =
+                when (playingQueueExpanded) {
+                  true -> "Collapse queue"
+                  false -> "Expand queue"
+                }
+            },
+        contentAlignment = Alignment.Center,
+      ) {
+        Box(
+          modifier =
+            Modifier
+              .width(36.dp)
+              .height(4.dp)
+              .clip(CircleShape)
+              .background(colorScheme.onBackground.copy(alpha = 0.16f)),
+        )
+      }
+
       if (playingQueueExpanded.not()) {
         Text(
           text = provideNowPlayingTitle(libraryViewModel.fetchPreferredLibraryType(), context),
@@ -272,6 +304,16 @@ fun PlayingQueueComposable(
                 ): Offset = if (playingQueueExpanded) Offset.Zero else available
 
                 override suspend fun onPreFling(available: Velocity): Velocity {
+                  if (
+                    available.y > collapseFlingThreshold &&
+                    playingQueueExpanded &&
+                    listState.firstVisibleItemIndex == 0 &&
+                    listState.firstVisibleItemScrollOffset == 0
+                  ) {
+                    viewModel.collapsePlayingQueue()
+                    return available
+                  }
+
                   if (available.y < -expandFlingThreshold && !playingQueueExpanded) {
                     viewModel.expandPlayingQueue()
                     return available


### PR DESCRIPTION
## what changed

- added vertical swipe handling on the full player so upward swipes expand chapters and downward swipes step back.
- added a per-gesture guard so one drag cannot fire repeated player actions.
- added an accessible queue grab handle with a 48dp tap target.
- made downward fling at the top of the expanded queue collapse chapters.

## why

this improves the chapter queue interaction without keeping the earlier fake mini-player expansion behavior.

## validation

- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew app:compileDebugKotlin`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew app:installDebug`
