### PR TITLE
Introduce download visibility badges

### DIFF
--- a/app/src/main/kotlin/org/grakovne/lissen/content/LissenMediaProvider.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/LissenMediaProvider.kt
@@ -190,26 +190,24 @@ class LissenMediaProvider
     ): OperationResult<PagedItems<LibraryEntry>> {
       Timber.d("Fetching library: libraryId=$libraryId, page=$pageNumber, pageSize=$pageSize")
 
-      return when (preferences.isForceCache()) {
-        true -> {
-          localCacheRepository.fetchLibrary(
-            libraryId = libraryId,
-            pageSize = pageSize,
-            pageNumber = pageNumber,
-            libraryGrouping = preferences.getLibraryGrouping(),
-          )
-        }
+      val grouping = preferences.getLibraryGrouping()
 
-        false -> {
-          providePreferredChannel()
-            .fetchLibrary(
-              libraryId = libraryId,
-              pageSize = pageSize,
-              pageNumber = pageNumber,
-              libraryGrouping = preferences.getLibraryGrouping(),
-            )
-        }
+      if (preferences.isForceCache()) {
+        return localCacheRepository.fetchLibrary(
+          libraryId = libraryId,
+          pageSize = pageSize,
+          pageNumber = pageNumber,
+          libraryGrouping = grouping,
+        )
       }
+
+      return providePreferredChannel()
+        .fetchLibrary(
+          libraryId = libraryId,
+          pageSize = pageSize,
+          pageNumber = pageNumber,
+          libraryGrouping = grouping,
+        )
     }
 
     suspend fun fetchSeriesItems(

--- a/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/LocalCacheRepository.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/LocalCacheRepository.kt
@@ -77,6 +77,10 @@ class LocalCacheRepository
         .searchBooks(libraryId = libraryId, query = query)
         .let { OperationResult.Success(it) }
 
+    suspend fun fetchCachedBookIds(): Set<String> = cachedBookRepository.fetchCachedBookIds()
+
+    fun observeCachedBookIds() = cachedBookRepository.observeCachedBookIds()
+
     suspend fun fetchDetailedItems(): OperationResult<PagedItems<DetailedItem>> {
       val items = cachedBookRepository.fetchCachedItems()
 

--- a/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/api/CachedBookRepository.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/api/CachedBookRepository.kt
@@ -93,6 +93,10 @@ class CachedBookRepository
 
     suspend fun countCachedItems(): Int = bookDao.fetchCachedItemsCount()
 
+    suspend fun fetchCachedBookIds(): Set<String> = bookDao.fetchAllCachedIds().toSet()
+
+    fun observeCachedBookIds() = bookDao.observeCachedIds()
+
     suspend fun fetchLatestUpdate(libraryId: String) = bookDao.fetchLatestUpdate(libraryId)
 
     suspend fun fetchBooks(

--- a/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/dao/CachedBookDao.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/dao/CachedBookDao.kt
@@ -210,6 +210,12 @@ interface CachedBookDao {
   @Query("SELECT COUNT(*) FROM detailed_books")
   suspend fun fetchCachedItemsCount(): Int
 
+  @Query("SELECT id FROM detailed_books")
+  suspend fun fetchAllCachedIds(): List<String>
+
+  @Query("SELECT id FROM detailed_books")
+  fun observeCachedIds(): Flow<List<String>>
+
   @Query(
     """
     SELECT COUNT(*) > 0

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/library/LibraryScreen.kt
@@ -140,6 +140,7 @@ fun LibraryScreen(
   val groupBooks by libraryViewModel.groupBooks.collectAsState()
   val groupLoading by libraryViewModel.groupLoading.collectAsState()
   val libraryGrouping by settingsViewModel.libraryGrouping.collectAsState(LibraryGrouping.NONE)
+  val downloadedIds by cachingModelView.cachedBookIds.collectAsState()
 
   val libraryListState = rememberLazyGridState()
 
@@ -531,6 +532,7 @@ fun LibraryScreen(
                       imageLoader = imageLoader,
                       navController = navController,
                       grouping = libraryGrouping,
+                      downloaded = entry.book.id in downloadedIds,
                     )
                   }
 
@@ -544,6 +546,7 @@ fun LibraryScreen(
                       navController = navController,
                       onToggle = { libraryViewModel.toggleGroup(entry) },
                       onPrefetch = { libraryViewModel.prefetchGroup(entry) },
+                      downloadedIds = downloadedIds,
                     )
                   }
 
@@ -557,6 +560,7 @@ fun LibraryScreen(
                       navController = navController,
                       onToggle = { libraryViewModel.toggleGroup(entry) },
                       onPrefetch = { libraryViewModel.prefetchGroup(entry) },
+                      downloadedIds = downloadedIds,
                     )
                   }
                 }

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/library/composables/AuthorComposable.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/library/composables/AuthorComposable.kt
@@ -59,6 +59,7 @@ fun AuthorComposable(
   navController: AppNavigationService,
   onToggle: () -> Unit,
   onPrefetch: () -> Unit,
+  downloadedIds: Set<String> = emptySet(),
 ) {
   val context = LocalContext.current
 
@@ -161,6 +162,7 @@ fun AuthorComposable(
                 imageLoader = imageLoader,
                 navController = navController,
                 grouping = LibraryGrouping.AUTHOR,
+                downloaded = book.id in downloadedIds,
                 leading = { AuthorBookLeading() },
               )
             }

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/library/composables/BookComposable.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/library/composables/BookComposable.kt
@@ -11,6 +11,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.DownloadForOffline
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -46,6 +49,7 @@ fun BookComposable(
   navController: AppNavigationService,
   grouping: LibraryGrouping = LibraryGrouping.NONE,
   leading: (@Composable () -> Unit)? = null,
+  downloaded: Boolean = false,
 ) {
   val context = LocalContext.current
 
@@ -105,6 +109,19 @@ fun BookComposable(
       }
 
       BookMetadataComposable(book, grouping)
+    }
+
+    if (downloaded) {
+      Spacer(Modifier.width(12.dp))
+      Icon(
+        imageVector = Icons.Outlined.DownloadForOffline,
+        contentDescription = stringResource(R.string.library_item_downloaded_indicator),
+        tint = MaterialTheme.colorScheme.primary,
+        modifier =
+          Modifier
+            .size(24.dp)
+            .testTag("downloadedIndicator_${book.id}"),
+      )
     }
 
     Spacer(Modifier.width(16.dp))

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/library/composables/SeriesComposable.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/library/composables/SeriesComposable.kt
@@ -60,6 +60,7 @@ fun SeriesComposable(
   navController: AppNavigationService,
   onToggle: () -> Unit,
   onPrefetch: () -> Unit,
+  downloadedIds: Set<String> = emptySet(),
 ) {
   val context = LocalContext.current
 
@@ -165,6 +166,7 @@ fun SeriesComposable(
                 imageLoader = imageLoader,
                 navController = navController,
                 grouping = LibraryGrouping.SERIES,
+                downloaded = book.id in downloadedIds,
                 leading = { SeriesSequenceLabel(number = sequences[index], widthReserve = widthReserve) },
               )
             }

--- a/app/src/main/kotlin/org/grakovne/lissen/viewmodel/CachingModelView.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/viewmodel/CachingModelView.kt
@@ -14,8 +14,11 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.grakovne.lissen.content.cache.persistent.CacheState
@@ -52,6 +55,16 @@ class CachingModelView
     val totalCount: StateFlow<Int> = _totalCount.asStateFlow()
 
     val forceCache = preferences.forceCacheFlow
+
+    /**
+     * Ids of all locally-cached books, observed once for the whole library list so rows can render a
+     * download badge without each subscribing its own database Flow.
+     */
+    val cachedBookIds: StateFlow<Set<String>> =
+      localCacheRepository
+        .observeCachedBookIds()
+        .map { it.toSet() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
 
     private val _bookCachingProgress = mutableMapOf<String, MutableStateFlow<CacheState>>()
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="login_error_host_url_shall_be_https_or_http">Host URL shall be https:// or http://</string>
     <string name="login_error_connection_error">Connection error</string>
     <string name="show_downloaded_content_only">Downloaded only</string>
+    <string name="library_item_downloaded_indicator">Downloaded</string>
     <string name="library_quick_settings_grouping_title">Grouping</string>
     <string name="library_grouping_disabled">Disabled</string>
     <string name="library_grouping_series">By Series</string>


### PR DESCRIPTION
Currently there isn't a solid way to know if a given piece of content is downloaded from the main list view. I've introduced a badge and accessibility tag to make this easier to understand.

## Testing
I tested this with the debug server on a Pixel 10 XL with latest GrapheneOS. Tests:
* Downloaded content, verified badge shows up on home page automatically on completion
* Clear download - verified that the download status is no longer shown in the home list.
* Unit tests

## Demo
<img width="1344" height="2992" alt="Screenshot_20260704-072727" src="https://github.com/user-attachments/assets/36bd1578-2a80-4a26-8b98-07bef834af3a" />

## Follow-up
I'd like to make the following fixes:
1. Clearer download state hint on details page (color cloud icon orange on download)
2. Show download state on home page (progress indicator)
3. Grouping > Downloaded first