### PR TITLE
Fix Android Auto seek buttons doing nothing when playback starts from the car screen

### DIFF
--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallback.kt
@@ -113,7 +113,7 @@ class MediaLibrarySessionCallback
           .setSessionCommand(prevChapterCommand)
           .setDisplayName("Previous Chapter")
           .setEnabled(true)
-          .setSlots(CommandButton.SLOT_BACK)
+          .setSlots(CommandButton.SLOT_OVERFLOW)
           .build()
 
       val nextChapterButton =
@@ -121,7 +121,7 @@ class MediaLibrarySessionCallback
           .Builder(CommandButton.ICON_NEXT)
           .setSessionCommand(nextChapterCommand)
           .setDisplayName("Next Chapter")
-          .setSlots(CommandButton.SLOT_FORWARD)
+          .setSlots(CommandButton.SLOT_OVERFLOW)
           .setEnabled(true)
           .build()
 
@@ -131,7 +131,7 @@ class MediaLibrarySessionCallback
           .setSessionCommand(rewindCommand)
           .setDisplayName("Rewind")
           .setEnabled(true)
-          .setSlots(CommandButton.SLOT_OVERFLOW)
+          .setSlots(CommandButton.SLOT_BACK)
           .build()
 
       val forwardButton =
@@ -139,7 +139,7 @@ class MediaLibrarySessionCallback
           .Builder(CommandButton.ICON_SKIP_FORWARD)
           .setSessionCommand(forwardCommand)
           .setDisplayName("Forward")
-          .setSlots(CommandButton.SLOT_OVERFLOW)
+          .setSlots(CommandButton.SLOT_FORWARD)
           .setEnabled(true)
           .build()
 
@@ -210,6 +210,7 @@ class MediaLibrarySessionCallback
                       preferences.savePlayingItem(it)
                       playbackSynchronizationService.startPlaybackSynchronization(it)
                     }
+                    mediaRepository.registerPlayingBook(it)
                     PlaybackService.bookToChapterMediaItems(it)
                   },
                   onFailure = { MediaItemsWithStartPosition(emptyList(), 0, 0) },

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
@@ -415,6 +415,18 @@ class MediaRepository
       _isPlaybackReady.value = false
     }
 
+    fun registerPlayingBook(book: DetailedItem) {
+      val sameBook = _playingBook.value?.same(book) ?: false
+
+      if (sameBook.not()) {
+        Timber.d("Registering playing book prepared via media session: ${book.id}")
+
+        _totalPosition.value = book.progress?.currentTime ?: 0.0
+        _playingBook.value = book
+        _isPlaybackReady.value = true
+      }
+    }
+
     private fun startPreparingPlayback(book: DetailedItem) {
       val sameBook = _playingBook.value?.same(book) ?: false
 


### PR DESCRIPTION
## AI disclosure

Up front, per the project's AI-assisted contribution policy: this change was diagnosed and implemented with AI assistance (Claude Code). The root-cause analysis was verified with a live logcat capture, and all changes were human-reviewed and manually tested end-to-end on the Desktop Head Unit by me.

Fixes #373

## Problem

When a book is started from the Android Auto browse screen (rather than from the phone UI first), none of the head-unit seek buttons do anything — rewind, forward, previous chapter, and next chapter are all silent no-ops, while play/pause keeps working. This matches the behavior described in #373: the buttons work only if the app UI was started before Android Auto.

## Root cause

Verified with `adb logcat` against the Desktop Head Unit: every button press does arrive at `MediaLibrarySessionCallback.onCustomCommand` (`Executing: notification_rewind` is logged per press), but no seek follows.

All four seek functions in `MediaRepository` begin with `val book = playingBook.value ?: return`. That state is only populated by the phone-UI flow (`startPreparingPlayback`). The Android Auto path (`onSetMediaItems`) saves the item to preferences and starts server sync, but never registers the book with `MediaRepository` — so `playingBook` stays `null` and every seek silently returns. Play/pause is unaffected because it goes straight to the player.

## Changes

1. `onSetMediaItems` now calls a new `MediaRepository.registerPlayingBook(book)`, which populates `playingBook`, seeds `totalPosition` from saved progress, and marks playback ready — without re-triggering preparation.
2. Swapped media button slots: the configurable Rewind/Forward now occupy `SLOT_BACK`/`SLOT_FORWARD` (the primary head-unit buttons), with Previous/Next Chapter moved to `SLOT_OVERFLOW`, matching common audiobook-app conventions. Happy to revert this part if you prefer chapter navigation primary.

This is the minimal state fix; the deeper refactor floated in #373 (deriving seeks purely from ExoPlayer's chapter-aware queue) would still be a nice follow-up and is untouched by this change.

## Testing

- Reproduced on the Desktop Head Unit before the fix: started a book from the car browse screen, pressed all four buttons — logcat showed the commands arriving but the position never changed.
- After the fix: rewind/forward/chapter buttons all work for car-initiated playback, and phone-initiated playback still behaves as before.
- `MediaLibrarySessionCallbackTest` (8 instrumented tests) passes on a Pixel 8 Pro; no test changes were needed (it injects a mocked `MediaRepository`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
