### PR TITLE
fix: avoid network in force-cache playback

### DIFF
--- a/app/src/main/kotlin/org/grakovne/lissen/content/LissenMediaProvider.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/LissenMediaProvider.kt
@@ -105,14 +105,10 @@ class LissenMediaProvider
 
       localCacheRepository.syncProgress(detailedItem, progress)
 
-      val channelSyncResult =
-        providePreferredChannel()
-          .syncProgress(sessionId, progress)
+      if (preferences.isForceCache()) return OperationResult.Success(Unit)
 
-      return when (preferences.isForceCache()) {
-        true -> OperationResult.Success(Unit)
-        false -> channelSyncResult
-      }
+      return providePreferredChannel()
+        .syncProgress(sessionId, progress)
     }
 
     suspend fun fetchBookCover(bookId: String): OperationResult<File> {
@@ -264,6 +260,8 @@ class LissenMediaProvider
       deviceId: String,
     ): OperationResult<PlaybackSession> {
       Timber.d("Starting playback: itemId=$itemId, chapterId=$chapterId, mimeTypes=$supportedMimeTypes")
+
+      if (preferences.isForceCache()) return OperationResult.Success(PlaybackSession.local(itemId))
 
       return providePreferredChannel()
         .startPlayback(

--- a/app/src/test/kotlin/org/grakovne/lissen/content/LissenMediaProviderTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/content/LissenMediaProviderTest.kt
@@ -259,6 +259,20 @@ class LissenMediaProviderTest {
   @Nested
   inner class StartPlayback {
     @Test
+    fun `returns local session without calling channel when force cache enabled`() =
+      runBlocking {
+        every { preferences.isForceCache() } returns true
+
+        val result = provider.startPlayback("book-1", "ep-1", listOf("audio/mp3"), "device-1")
+
+        assertInstanceOf(OperationResult.Success::class.java, result)
+        val session = (result as OperationResult.Success).data
+        assertEquals("book-1", session.itemId)
+        assertEquals(org.grakovne.lissen.domain.PlaybackSessionSource.LOCAL, session.sessionSource)
+        coVerify(exactly = 0) { mediaChannel.startPlayback(any(), any(), any(), any()) }
+      }
+
+    @Test
     fun `returns remote session on channel success`() =
       runBlocking {
         val session = PlaybackSession.remote("session-1", "book-1")
@@ -307,6 +321,7 @@ class LissenMediaProviderTest {
         val result = provider.syncProgress("session-1", item, progress)
 
         assertInstanceOf(OperationResult.Success::class.java, result)
+        coVerify(exactly = 0) { mediaChannel.syncProgress(any(), any()) }
       }
 
     @Test


### PR DESCRIPTION
## Summary

- return a local playback session immediately when force-cache mode is enabled
- persist progress locally without calling the media channel in force-cache mode
- add regression tests verifying that neither path contacts the channel

Fixes #473

## Regression

The force-cache branches were removed by [`2e8bd77f`](https://github.com/GrakovNe/lissen-android/commit/2e8bd77fa99c663ed60ca945c3eb14d09f9488f6) (`Consistent Sync`, April 22, 2025).

## Testing

- `git diff --check`
- Gradle unit tests could not be executed locally because the Android SDK is not configured in this environment (missing `ANDROID_HOME` / `local.properties`).