### PR TITLE
Resume the last played book on Android Auto connect

### DIFF
--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaButtonReceiverTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaButtonReceiverTest.kt
@@ -1,0 +1,122 @@
+package org.grakovne.lissen.playback
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import org.grakovne.lissen.domain.BookFile
+import org.grakovne.lissen.domain.DetailedItem
+import org.grakovne.lissen.domain.PlayingChapter
+import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LissenMediaButtonReceiverTest {
+  private lateinit var context: Context
+  private lateinit var preferences: PlaybackPreferences
+  private lateinit var receiver: TestMediaButtonReceiver
+
+  @Before
+  fun setUp() {
+    context = ApplicationProvider.getApplicationContext()
+    preferences = mockk(relaxed = true)
+    receiver = TestMediaButtonReceiver(preferences)
+  }
+
+  @Test
+  fun shouldStartForegroundService_noStoredPlayingItem_returnsFalse() {
+    every { preferences.getPlayingItem() } returns null
+
+    val result = receiver.exposeShouldStartForegroundService(context, Intent())
+
+    assertFalse(result)
+  }
+
+  @Test
+  fun shouldStartForegroundService_storedPlayingItemWithChapters_returnsTrue() {
+    every { preferences.getPlayingItem() } returns makePlayingItem(chapterCount = 1, fileCount = 1)
+
+    val result = receiver.exposeShouldStartForegroundService(context, Intent())
+
+    assertTrue(result)
+  }
+
+  @Test
+  fun shouldStartForegroundService_storedPlayingItemWithoutChapters_returnsFalse() {
+    every { preferences.getPlayingItem() } returns makePlayingItem(chapterCount = 0, fileCount = 1)
+
+    val result = receiver.exposeShouldStartForegroundService(context, Intent())
+
+    assertFalse(result)
+  }
+
+  @Test
+  fun shouldStartForegroundService_storedPlayingItemWithChaptersButWithoutFiles_returnsFalse() {
+    every { preferences.getPlayingItem() } returns makePlayingItem(chapterCount = 1, fileCount = 0)
+
+    val result = receiver.exposeShouldStartForegroundService(context, Intent())
+
+    assertFalse(result)
+  }
+
+  private fun makePlayingItem(
+    chapterCount: Int,
+    fileCount: Int,
+  ) = DetailedItem(
+    id = "book-1",
+    title = "My Book",
+    subtitle = null,
+    author = "Author",
+    narrator = null,
+    publisher = null,
+    series = emptyList(),
+    year = null,
+    abstract = null,
+    files =
+      (0 until fileCount).map { index ->
+        BookFile(
+          id = "f-$index",
+          name = "track-${index + 1}.mp3",
+          duration = 100.0,
+          size = null,
+          mimeType = "audio/mpeg",
+        )
+      },
+    chapters =
+      (0 until chapterCount).map { index ->
+        PlayingChapter(
+          available = true,
+          podcastEpisodeState = null,
+          duration = 150.0,
+          start = 0.0,
+          end = 150.0,
+          title = "Chapter ${index + 1}",
+          id = "c-$index",
+        )
+      },
+    progress = null,
+    libraryId = "lib-1",
+    localProvided = false,
+    createdAt = 0L,
+    updatedAt = 0L,
+  )
+
+  private class TestMediaButtonReceiver(
+    mockPreferences: PlaybackPreferences,
+  ) : LissenMediaButtonReceiver() {
+    init {
+      preferences = mockPreferences
+    }
+
+    fun exposeShouldStartForegroundService(
+      context: Context,
+      intent: Intent,
+    ) = shouldStartForegroundService(context, intent)
+  }
+}

--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallbackTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallbackTest.kt
@@ -16,9 +16,11 @@ import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.SettableFuture
 import io.mockk.Ordering
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.grakovne.lissen.channel.common.OperationError
 import org.grakovne.lissen.channel.common.OperationResult
@@ -33,10 +35,12 @@ import org.grakovne.lissen.playback.service.PlaybackService.Companion.FILE_SEGME
 import org.grakovne.lissen.playback.service.PlaybackSynchronizationService
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 
 @OptIn(UnstableApi::class)
@@ -196,6 +200,166 @@ class MediaLibrarySessionCallbackTest {
           .get(5, TimeUnit.SECONDS)
 
       assertTrue(result.mediaItems.isEmpty())
+    }
+
+  @Test
+  fun onPlaybackResumption_storedBook_refreshesAndResolvesQueue() =
+    runBlocking {
+      val storedBook = makeDetailedItem("book-1", "Stored Book", MediaProgress(170.0, false, 0L))
+      val refreshedBook = makeDetailedItem("book-1", "Refreshed Book", MediaProgress(170.0, false, 0L))
+      every { preferences.getPlayingItem() } returns storedBook
+      coEvery { lissenMediaProvider.fetchBook("book-1") } returns OperationResult.Success(refreshedBook)
+
+      val result =
+        callback
+          .onPlaybackResumption(session, controller, isForPlayback = true)
+          .get(5, TimeUnit.SECONDS)
+
+      assertEquals(listOf("chapter:book-1:0", "chapter:book-1:1"), result.mediaItems.map { it.mediaId })
+      assertEquals(1, result.startIndex)
+      assertEquals(20000, result.startPositionMs)
+      assertEquals(
+        "Refreshed Book",
+        result.mediaItems[0]
+          .mediaMetadata.albumTitle
+          .toString(),
+      )
+      verify(exactly = 1) { preferences.savePlayingItem(refreshedBook) }
+      verify(exactly = 1) { playbackSynchronizationService.startPlaybackSynchronization(refreshedBook) }
+      verify(exactly = 1) { mediaRepository.registerPlayingBook(refreshedBook) }
+    }
+
+  @Test
+  fun onPlaybackResumption_noStoredBook_returnsFailedFutureWithoutSideEffects() =
+    runBlocking {
+      every { preferences.getPlayingItem() } returns null
+
+      val future = callback.onPlaybackResumption(session, controller, isForPlayback = true)
+
+      assertThrows(ExecutionException::class.java) { future.get(5, TimeUnit.SECONDS) }
+      coVerify(exactly = 0) { lissenMediaProvider.fetchBook(any()) }
+      verify(exactly = 0) { preferences.savePlayingItem(any()) }
+      verify(exactly = 0) { playbackSynchronizationService.startPlaybackSynchronization(any()) }
+      verify(exactly = 0) { mediaRepository.registerPlayingBook(any()) }
+    }
+
+  @Test
+  fun onPlaybackResumption_fetchBookFails_fallsBackToStoredBook() =
+    runBlocking {
+      val storedBook = makeDetailedItem("book-1", "My Book", MediaProgress(170.0, false, 0L))
+      every { preferences.getPlayingItem() } returns storedBook
+      coEvery { lissenMediaProvider.fetchBook("book-1") } returns
+        OperationResult.Error(OperationError.NotFoundError)
+
+      val result =
+        callback
+          .onPlaybackResumption(session, controller, isForPlayback = true)
+          .get(5, TimeUnit.SECONDS)
+
+      assertEquals(listOf("chapter:book-1:0", "chapter:book-1:1"), result.mediaItems.map { it.mediaId })
+      assertEquals(1, result.startIndex)
+      assertEquals(20000, result.startPositionMs)
+      verify(exactly = 1) { preferences.savePlayingItem(storedBook) }
+      verify(exactly = 1) { playbackSynchronizationService.startPlaybackSynchronization(storedBook) }
+      verify(exactly = 1) { mediaRepository.registerPlayingBook(storedBook) }
+    }
+
+  @Test
+  fun onPlaybackResumption_metadataOnlyRequest_skipsPlaybackSideEffects() =
+    runBlocking {
+      val storedBook = makeDetailedItem("book-1", "My Book", MediaProgress(170.0, false, 0L))
+      every { preferences.getPlayingItem() } returns storedBook
+      coEvery { lissenMediaProvider.fetchBook("book-1") } returns OperationResult.Success(storedBook)
+
+      val result =
+        callback
+          .onPlaybackResumption(session, controller, isForPlayback = false)
+          .get(5, TimeUnit.SECONDS)
+
+      assertEquals(listOf("chapter:book-1:0", "chapter:book-1:1"), result.mediaItems.map { it.mediaId })
+      assertEquals(1, result.startIndex)
+      assertEquals(20000, result.startPositionMs)
+      verify(exactly = 0) { preferences.savePlayingItem(any()) }
+      verify(exactly = 0) { playbackSynchronizationService.startPlaybackSynchronization(any()) }
+      verify(exactly = 0) { mediaRepository.registerPlayingBook(any()) }
+    }
+
+  @Test
+  fun onPlaybackResumption_fetchBookStalls_fallsBackToStoredBook() =
+    runBlocking {
+      val storedBook = makeDetailedItem("book-1", "My Book", MediaProgress(170.0, false, 0L))
+      val slowBook = makeDetailedItem("book-1", "Slow Book", MediaProgress(170.0, false, 0L))
+      every { preferences.getPlayingItem() } returns storedBook
+      coEvery { lissenMediaProvider.fetchBook("book-1") } coAnswers {
+        delay(5_000)
+        OperationResult.Success(slowBook)
+      }
+
+      val startedAt = System.nanoTime()
+      val result =
+        callback
+          .onPlaybackResumption(session, controller, isForPlayback = true)
+          .get(10, TimeUnit.SECONDS)
+      val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+
+      assertTrue(elapsedMs < 4_500)
+      assertEquals(listOf("chapter:book-1:0", "chapter:book-1:1"), result.mediaItems.map { it.mediaId })
+      assertEquals(1, result.startIndex)
+      assertEquals(20000, result.startPositionMs)
+      assertEquals(
+        "My Book",
+        result.mediaItems[0]
+          .mediaMetadata
+          .albumTitle
+          .toString(),
+      )
+      verify(exactly = 1) { preferences.savePlayingItem(storedBook) }
+      verify(exactly = 1) { playbackSynchronizationService.startPlaybackSynchronization(storedBook) }
+      verify(exactly = 1) { mediaRepository.registerPlayingBook(storedBook) }
+    }
+
+  @Test
+  fun onPlaybackResumption_refreshedBookUnusable_fallsBackToStoredBook() =
+    runBlocking {
+      val storedBook = makeDetailedItem("book-1", "My Book", MediaProgress(170.0, false, 0L))
+      val unusableBook =
+        makeDetailedItem("book-1", "Unusable Book", MediaProgress(170.0, false, 0L)).copy(files = emptyList())
+      every { preferences.getPlayingItem() } returns storedBook
+      coEvery { lissenMediaProvider.fetchBook("book-1") } returns OperationResult.Success(unusableBook)
+
+      val result =
+        callback
+          .onPlaybackResumption(session, controller, isForPlayback = true)
+          .get(5, TimeUnit.SECONDS)
+
+      assertEquals(listOf("chapter:book-1:0", "chapter:book-1:1"), result.mediaItems.map { it.mediaId })
+      assertEquals(1, result.startIndex)
+      assertEquals(20000, result.startPositionMs)
+      assertEquals(
+        "My Book",
+        result.mediaItems[0]
+          .mediaMetadata
+          .albumTitle
+          .toString(),
+      )
+      verify(exactly = 1) { preferences.savePlayingItem(storedBook) }
+      verify(exactly = 1) { playbackSynchronizationService.startPlaybackSynchronization(storedBook) }
+      verify(exactly = 1) { mediaRepository.registerPlayingBook(storedBook) }
+    }
+
+  @Test
+  fun onPlaybackResumption_storedBookUnusable_returnsFailedFutureWithoutSideEffects() =
+    runBlocking {
+      val storedBook = makeDetailedItem("book-1", "My Book").copy(files = emptyList())
+      every { preferences.getPlayingItem() } returns storedBook
+      coEvery { lissenMediaProvider.fetchBook("book-1") } returns OperationResult.Success(storedBook)
+
+      val future = callback.onPlaybackResumption(session, controller, isForPlayback = true)
+
+      assertThrows(ExecutionException::class.java) { future.get(5, TimeUnit.SECONDS) }
+      verify(exactly = 0) { preferences.savePlayingItem(any()) }
+      verify(exactly = 0) { playbackSynchronizationService.startPlaybackSynchronization(any()) }
+      verify(exactly = 0) { mediaRepository.registerPlayingBook(any()) }
     }
 
   private fun makePlayableMediaItem(id: String) =

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,6 +86,14 @@
             </intent-filter>
         </service>
 
+        <receiver
+            android:name=".playback.LissenMediaButtonReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
+
         <service
             android:name=".content.cache.persistent.ContentCachingService"
             android:exported="false"

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/LissenMediaButtonReceiver.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/LissenMediaButtonReceiver.kt
@@ -1,0 +1,22 @@
+package org.grakovne.lissen.playback
+
+import android.content.Context
+import android.content.Intent
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaButtonReceiver
+import dagger.hilt.android.AndroidEntryPoint
+import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
+import javax.inject.Inject
+
+@OptIn(UnstableApi::class)
+@AndroidEntryPoint
+open class LissenMediaButtonReceiver : MediaButtonReceiver() {
+  @Inject
+  lateinit var preferences: PlaybackPreferences
+
+  override fun shouldStartForegroundService(
+    context: Context,
+    intent: Intent,
+  ): Boolean = preferences.getPlayingItem()?.canProducePlaybackQueue() == true
+}

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallback.kt
@@ -27,6 +27,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withTimeoutOrNull
+import org.grakovne.lissen.channel.common.OperationResult
 import org.grakovne.lissen.content.LissenMediaProvider
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
 import org.grakovne.lissen.playback.service.PlaybackService
@@ -218,6 +220,70 @@ class MediaLibrarySessionCallback
         }
       } ?: super.onSetMediaItems(mediaSession, controller, mediaItems, startIndex, startPositionMs)
 
+    override fun onPlaybackResumption(
+      mediaSession: MediaSession,
+      controller: MediaSession.ControllerInfo,
+      isForPlayback: Boolean,
+    ): ListenableFuture<MediaItemsWithStartPosition> {
+      Timber.d("Resuming playback for: $controller (isForPlayback=$isForPlayback)")
+
+      val storedBook =
+        preferences.getPlayingItem()
+          ?: return Futures.immediateFailedFuture(IllegalStateException("No last played book stored"))
+
+      return futureScope
+        .listenableFuture {
+          val refreshedBook =
+            withTimeoutOrNull(REFRESH_TIMEOUT_MS) {
+              lissenMediaProvider.fetchBook(storedBook.id)
+            }
+
+          val book =
+            when {
+              refreshedBook is OperationResult.Success && refreshedBook.data.canProducePlaybackQueue() -> {
+                refreshedBook.data
+              }
+
+              refreshedBook is OperationResult.Error -> {
+                Timber.w(
+                  "Unable to refresh last played book (bookId=${storedBook.id}) for resumption, " +
+                    "falling back to stored copy due to: ${refreshedBook.message}",
+                )
+                storedBook
+              }
+
+              refreshedBook == null -> {
+                Timber.w(
+                  "Timed out refreshing last played book (bookId=${storedBook.id}) for resumption, " +
+                    "falling back to stored copy",
+                )
+                storedBook
+              }
+
+              else -> {
+                Timber.w(
+                  "Refreshed last played book (bookId=${storedBook.id}) can't produce a playback " +
+                    "queue, falling back to stored copy",
+                )
+                storedBook
+              }
+            }
+
+          if (!book.canProducePlaybackQueue()) {
+            Timber.w("Can't build resumption queue: book has no chapters or files (bookId=${book.id})")
+            throw IllegalStateException("Stored book can't produce a playback queue (bookId=${book.id})")
+          }
+
+          if (isForPlayback) {
+            preferences.savePlayingItem(book)
+            playbackSynchronizationService.startPlaybackSynchronization(book)
+            mediaRepository.registerPlayingBook(book)
+          }
+
+          PlaybackService.bookToChapterMediaItems(book)
+        }
+    }
+
     override fun onSearch(
       session: MediaLibraryService.MediaLibrarySession,
       browser: MediaSession.ControllerInfo,
@@ -272,6 +338,12 @@ class MediaLibrarySessionCallback
       internal const val REWIND_COMMAND = "notification_rewind"
       internal const val FORWARD_COMMAND = "notification_forward"
       internal const val NEXT_CHAPTER_COMMAND = "notification_next_chapter"
+
+      // Deliberately much shorter than the OkHttp timeouts (connect 20 s / read 120 s): the
+      // foreground-service start window after startForegroundService is only a few seconds, and
+      // the stored copy is nearly always correct because it is refreshed whenever the book is
+      // opened, so a fast start beats freshness here.
+      private const val REFRESH_TIMEOUT_MS = 2_000L
     }
   }
 

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/PlaybackResumability.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/PlaybackResumability.kt
@@ -1,0 +1,12 @@
+package org.grakovne.lissen.playback
+
+import org.grakovne.lissen.domain.DetailedItem
+
+/**
+ * Reports whether this book can produce a non-empty playback queue.
+ *
+ * PlaybackService.bookToChapterMediaItems resolves chapters against files and returns an
+ * empty queue when either list is empty, so both must be non-empty for the book to be
+ * resumable.
+ */
+internal fun DetailedItem.canProducePlaybackQueue(): Boolean = chapters.isNotEmpty() && files.isNotEmpty()


### PR DESCRIPTION
Hello, I had an issue where Lissen doesn't start when I get in the car, and asks me to pick the last book instead. I figured I'd send a PR, but feel free to ignore the AI stuff and redo it yourself.

This is what the AI said:

### Problem

When the phone connects to Android Auto, the media session has nothing loaded, so Auto lands the user in the browse tree and they must pick a book before anything can play. The app already stores the last played item and its progress, so the information needed to continue is there; there was simply no hook to hand it to Auto.

### Change

Implement `MediaSession.Callback.onPlaybackResumption` in `MediaLibrarySessionCallback`. It:

- takes the last played item from `PlaybackPreferences.getPlayingItem()` (unchanged per-library scoping),
- refreshes it through `LissenMediaProvider.fetchBook`, so progress listened on another device is honoured, and falls back to the stored copy on failure,
- returns `PlaybackService.bookToChapterMediaItems(book)`, which already positions the queue at the saved chapter and offset,
- mirrors the `onSetMediaItems` side effects (`savePlayingItem`, `startPlaybackSynchronization`, `registerPlayingBook`) only when `isForPlayback` is true, so a metadata-only query does not open a server playback session.

The refresh is bounded at 2 s with a fallback to the stored copy. The OkHttp read timeout is 120 s, and an unreachable or slow server must not keep the user waiting in silence, nor delay a foreground-service promotion past its window. The stored copy is refreshed whenever the book is opened, so it is nearly always correct; a fast start is worth more than freshness here.

A `MediaButtonReceiver` is also declared so the system can wake `PlaybackService` when the process is dead. This is what makes the notification resume tile and the Play button on a Bluetooth headset work as well. It is gated by `shouldStartForegroundService`, so the service is never started when the stored item cannot produce a queue. A single shared predicate, `DetailedItem.canProducePlaybackQueue()`, backs both that gate and the callback's own validation; it checks chapters **and** files, because `resolveChapterToFiles` yields an empty queue if either list is empty.

### Deliberately not included

Nothing forces playback to start without a tap. No car-connect broadcast receiver, no `CarConnection` observer calling `play()`. Whether sound starts by itself is decided by Android Auto and the head unit; in practice a setup with autoplay enabled will resume on its own once the app supports resumption.

No new dependencies, no new user setting, no change to the browse tree or the phone UI.

### Tests

New instrumented cases in `MediaLibrarySessionCallbackTest` cover the happy path, no stored book, a failed refresh falling back to the stored copy, a stalled refresh hitting the 2 s bound, an unusable refreshed book, an unusable stored book, and the metadata-only path. `LissenMediaButtonReceiverTest` covers the gating decision, including chapters present with no files.

`./gradlew lintKotlin`, `./gradlew build` and `./gradlew testDebugUnitTest` pass. The instrumented tests compile but were not run, as no device was available in my environment.

### AI assistance

This was written with AI assistance and then reviewed. Three review rounds were run against it; each found a real defect, and all are fixed here. I have not been able to verify the behaviour on a real head unit, so on-device confirmation would be welcome before merging.