### PR TITLE
Fix dead skip-unavailable-track logic

### DIFF
--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
@@ -1,5 +1,6 @@
 package org.grakovne.lissen.playback
 
+import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -43,6 +44,13 @@ class LissenMediaSourceFactoryTest {
     assertEquals(mediaItem.mediaId, reportedItem.mediaId)
     assertEquals(mediaItem.requestMetadata, reportedItem.requestMetadata)
     assertEquals(mediaItem.mediaMetadata, reportedItem.mediaMetadata)
+    assertEquals(500_000L, reportedItem.mediaMetadata.extras?.getLong(CHAPTER_START_MS))
+    val reportedSegments =
+      reportedItem.requestMetadata.extras?.let {
+        BundleCompat.getParcelableArrayList(it, FILE_SEGMENTS, FileClip::class.java)
+      }
+    assertNotNull(reportedSegments)
+    assertEquals(1, reportedSegments!!.size)
   }
 
   @Test
@@ -60,6 +68,13 @@ class LissenMediaSourceFactoryTest {
     assertEquals(mediaItem.mediaId, reportedItem.mediaId)
     assertEquals(mediaItem.requestMetadata, reportedItem.requestMetadata)
     assertEquals(mediaItem.mediaMetadata, reportedItem.mediaMetadata)
+    assertEquals(500_000L, reportedItem.mediaMetadata.extras?.getLong(CHAPTER_START_MS))
+    val reportedSegments =
+      reportedItem.requestMetadata.extras?.let {
+        BundleCompat.getParcelableArrayList(it, FILE_SEGMENTS, FileClip::class.java)
+      }
+    assertNotNull(reportedSegments)
+    assertEquals(2, reportedSegments!!.size)
   }
 
   private fun chapterMediaItem(segments: ArrayList<FileClip>): MediaItem =

--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
@@ -19,6 +19,13 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
+// The factory is given a DataSource.Factory rather than a DefaultMediaSourceFactory so that these
+// tests assert on the MediaSource the factory returns, which is what BasePlayer.getCurrentMediaItem
+// reads via the timeline window. Mocking the inner factory would only prove what we passed into it.
+//
+// The extras assertions are not redundant with the enclosing metadata assertions: in Media3 1.11.0,
+// MediaMetadata.equals and RequestMetadata.equals only check whether extras is null, never its
+// contents. FILE_SEGMENTS and CHAPTER_START_MS have to be checked by hand.
 class LissenMediaSourceFactoryTest {
   private lateinit var lissenMediaSourceFactory: LissenMediaSourceFactory
 

--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
@@ -5,12 +5,15 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import org.grakovne.lissen.content.ExternalCoverProvider
 import org.grakovne.lissen.playback.service.FileClip
 import org.grakovne.lissen.playback.service.LissenMediaSourceFactory
 import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_START_MS
 import org.grakovne.lissen.playback.service.PlaybackService.Companion.FILE_SEGMENTS
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
@@ -29,30 +32,60 @@ class LissenMediaSourceFactoryTest {
 
   @Test
   fun no_exception_thrown_if_no_files() {
-    val mediaSource =
-      lissenMediaSourceFactory.createMediaSource(
-        MediaItem
-          .Builder()
-          .setMediaId(LissenMediaSourceFactory.MediaId("book-id", 5).toString())
-          .setRequestMetadata(
-            MediaItem.RequestMetadata
-              .Builder()
-              .setExtras(bundleOf(FILE_SEGMENTS to arrayListOf<FileClip>()))
-              .build(),
-          ).setMediaMetadata(
-            MediaMetadata
-              .Builder()
-              .setAlbumTitle("title")
-              .setTitle("chapter")
-              .setArtist("book")
-              .setIsBrowsable(false)
-              .setIsPlayable(true)
-              .setArtworkUri(ExternalCoverProvider.bookCoverUri("book-id"))
-              .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK_CHAPTER)
-              .setExtras(bundleOf(CHAPTER_START_MS to (500 * 1000).toLong()))
-              .build(),
-          ).build(),
-      )
+    val mediaSource = lissenMediaSourceFactory.createMediaSource(chapterMediaItem(arrayListOf()))
     assertNotNull(mediaSource)
   }
+
+  @Test
+  fun media_id_and_request_metadata_preserved_for_single_segment_chapter() {
+    val capturedItem = slot<MediaItem>()
+    every { mediaSourceFactory.createMediaSource(capture(capturedItem)) } returns mockk(relaxed = true)
+
+    val mediaItem = chapterMediaItem(arrayListOf(FileClip("file-1", 0.0, 30.0)))
+    lissenMediaSourceFactory.createMediaSource(mediaItem)
+
+    assertEquals(mediaItem.mediaId, capturedItem.captured.mediaId)
+    assertEquals(mediaItem.requestMetadata, capturedItem.captured.requestMetadata)
+    assertEquals(mediaItem.mediaMetadata, capturedItem.captured.mediaMetadata)
+  }
+
+  @Test
+  fun media_id_and_request_metadata_preserved_for_multi_segment_chapter() {
+    val mediaItem =
+      chapterMediaItem(
+        arrayListOf(
+          FileClip("file-1", 0.0, 30.0),
+          FileClip("file-2", 30.0, 60.0),
+        ),
+      )
+
+    val reportedItem = lissenMediaSourceFactory.createMediaSource(mediaItem).mediaItem
+
+    assertEquals(mediaItem.mediaId, reportedItem.mediaId)
+    assertEquals(mediaItem.requestMetadata, reportedItem.requestMetadata)
+    assertEquals(mediaItem.mediaMetadata, reportedItem.mediaMetadata)
+  }
+
+  private fun chapterMediaItem(segments: ArrayList<FileClip>): MediaItem =
+    MediaItem
+      .Builder()
+      .setMediaId(LissenMediaSourceFactory.MediaId("book-id", 5).toString())
+      .setRequestMetadata(
+        MediaItem.RequestMetadata
+          .Builder()
+          .setExtras(bundleOf(FILE_SEGMENTS to segments))
+          .build(),
+      ).setMediaMetadata(
+        MediaMetadata
+          .Builder()
+          .setAlbumTitle("title")
+          .setTitle("chapter")
+          .setArtist("book")
+          .setIsBrowsable(false)
+          .setIsPlayable(true)
+          .setArtworkUri(ExternalCoverProvider.bookCoverUri("book-id"))
+          .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK_CHAPTER)
+          .setExtras(bundleOf(CHAPTER_START_MS to (500 * 1000).toLong()))
+          .build(),
+      ).build()
 }

--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
@@ -3,13 +3,11 @@ package org.grakovne.lissen.playback
 import androidx.core.os.bundleOf
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
-import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import org.grakovne.lissen.content.ExternalCoverProvider
 import org.grakovne.lissen.playback.service.FileClip
+import org.grakovne.lissen.playback.service.LissenDataSourceFactory
 import org.grakovne.lissen.playback.service.LissenMediaSourceFactory
 import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_START_MS
 import org.grakovne.lissen.playback.service.PlaybackService.Companion.FILE_SEGMENTS
@@ -21,13 +19,14 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class LissenMediaSourceFactoryTest {
-  private lateinit var mediaSourceFactory: DefaultMediaSourceFactory
   private lateinit var lissenMediaSourceFactory: LissenMediaSourceFactory
+
+  private lateinit var lissenDataSourceFactory: LissenDataSourceFactory
 
   @Before
   fun setUp() {
-    mediaSourceFactory = mockk(relaxed = true)
-    lissenMediaSourceFactory = LissenMediaSourceFactory(mediaSourceFactory)
+    lissenDataSourceFactory = mockk(relaxed = true)
+    lissenMediaSourceFactory = LissenMediaSourceFactory(lissenDataSourceFactory)
   }
 
   @Test
@@ -38,15 +37,12 @@ class LissenMediaSourceFactoryTest {
 
   @Test
   fun media_id_and_request_metadata_preserved_for_single_segment_chapter() {
-    val capturedItem = slot<MediaItem>()
-    every { mediaSourceFactory.createMediaSource(capture(capturedItem)) } returns mockk(relaxed = true)
-
     val mediaItem = chapterMediaItem(arrayListOf(FileClip("file-1", 0.0, 30.0)))
-    lissenMediaSourceFactory.createMediaSource(mediaItem)
+    val reportedItem = lissenMediaSourceFactory.createMediaSource(mediaItem).mediaItem
 
-    assertEquals(mediaItem.mediaId, capturedItem.captured.mediaId)
-    assertEquals(mediaItem.requestMetadata, capturedItem.captured.requestMetadata)
-    assertEquals(mediaItem.mediaMetadata, capturedItem.captured.mediaMetadata)
+    assertEquals(mediaItem.mediaId, reportedItem.mediaId)
+    assertEquals(mediaItem.requestMetadata, reportedItem.requestMetadata)
+    assertEquals(mediaItem.mediaMetadata, reportedItem.mediaMetadata)
   }
 
   @Test

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaModule.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaModule.kt
@@ -92,16 +92,14 @@ object MediaModule {
         ).setRenderersFactory(renderersFactory)
         .setMediaSourceFactory(
           LissenMediaSourceFactory(
-            mediaSourceFactory =
-              DefaultMediaSourceFactory(
-                LissenDataSourceFactory(
-                  baseContext = context,
-                  mediaCache = mediaCache,
-                  requestHeadersProvider = requestHeadersProvider,
-                  session = sessionPreferences,
-                  connection = connectionPreferences,
-                  mediaProvider = mediaProvider,
-                ),
+            dataSourceFactory =
+              LissenDataSourceFactory(
+                baseContext = context,
+                mediaCache = mediaCache,
+                requestHeadersProvider = requestHeadersProvider,
+                session = sessionPreferences,
+                connection = connectionPreferences,
+                mediaProvider = mediaProvider,
               ),
           ),
         ).build()

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactory.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactory.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.core.os.BundleCompat
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.ClippingMediaSource
 import androidx.media3.exoplayer.source.ConcatenatingMediaSource2
@@ -23,8 +24,10 @@ data class FileClip(
 
 @UnstableApi
 class LissenMediaSourceFactory(
-  private val mediaSourceFactory: DefaultMediaSourceFactory,
+  dataSourceFactory: DataSource.Factory,
 ) : MediaSource.Factory {
+  private val mediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory)
+
   data class MediaId(
     val bookId: String,
     val chapterId: Int,

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactory.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactory.kt
@@ -3,7 +3,6 @@ package org.grakovne.lissen.playback.service
 import android.os.Parcelable
 import androidx.core.os.BundleCompat
 import androidx.media3.common.MediaItem
-import androidx.media3.common.MediaMetadata
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.ClippingMediaSource
@@ -59,25 +58,33 @@ class LissenMediaSourceFactory(
 
   override fun getSupportedTypes(): IntArray = mediaSourceFactory.supportedTypes
 
+  /**
+   * The player reports the MediaItem of the MediaSource we return here, not the one it was given:
+   * both getCurrentMediaItem() and getMediaItemAt() read Timeline.Window.mediaItem, and that comes
+   * from the created source. So every source we build must carry the chapter item's identity
+   * (mediaId, requestMetadata with FILE_SEGMENTS, mediaMetadata with CHAPTER_START_MS) or it becomes
+   * invisible to PlaybackNavigationService and PlaybackSynchronizationService. Do not drop it.
+   */
   override fun createMediaSource(mediaItem: MediaItem): MediaSource {
     fun FileClip.toMediaSource(
       bookId: String,
-      metadata: MediaMetadata? = null,
-    ): MediaSource =
-      mediaSourceFactory
-        .createMediaSource(
-          MediaItem
-            .Builder()
-            .setUri(toLissenUri(bookId, fileId))
-            .apply { metadata?.let { setMediaMetadata(it) } }
-            .build(),
-        ).let {
+      template: MediaItem? = null,
+    ): MediaSource {
+      val innerItem =
+        (template?.buildUpon() ?: MediaItem.Builder())
+          .setUri(toLissenUri(bookId, fileId))
+          .build()
+
+      return mediaSourceFactory
+        .createMediaSource(innerItem)
+        .let {
           ClippingMediaSource
             .Builder(it)
             .setStartPositionUs((clipStart * 1_000_000).toLong())
             .setEndPositionUs((clipEnd * 1_000_000).toLong())
             .build()
         }
+    }
 
     return MediaId.fromString(mediaItem.mediaId)?.let { (bookId, chapterId) ->
       mediaItem.requestMetadata.extras?.let { extras ->
@@ -88,7 +95,7 @@ class LissenMediaSourceFactory(
             }
 
             1 -> {
-              segments.first().toMediaSource(bookId, mediaItem.mediaMetadata)
+              segments.first().toMediaSource(bookId, mediaItem)
             }
 
             else -> {
@@ -98,12 +105,8 @@ class LissenMediaSourceFactory(
                   segments.forEach {
                     add(it.toMediaSource(bookId), ((it.clipEnd - it.clipStart) * 1000).toLong())
                   }
-                }.setMediaItem(
-                  MediaItem
-                    .Builder()
-                    .setMediaMetadata(mediaItem.mediaMetadata)
-                    .build(),
-                ).build()
+                }.setMediaItem(mediaItem)
+                .build()
             }
           }
         }

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackNavigationService.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackNavigationService.kt
@@ -7,7 +7,6 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import org.grakovne.lissen.common.RunningComponent
 import org.grakovne.lissen.content.LissenMediaProvider
-import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -36,6 +35,12 @@ class PlaybackNavigationService
             }
           }
 
+          /**
+           * Skips chapters whose files are missing, which happens in offline mode when a book is
+           * only partly downloaded. Known limitation: this only covers transitions between items,
+           * so an unavailable first chapter is not skipped and still fails on load. Setting the
+           * playlist raises onTimelineChanged, not a discontinuity, so we never see it here.
+           */
           override fun onPositionDiscontinuity(
             oldPosition: Player.PositionInfo,
             newPosition: Player.PositionInfo,
@@ -43,15 +48,6 @@ class PlaybackNavigationService
           ) {
             val previousIndex = oldPosition.mediaItemIndex
             val currentIndex = newPosition.mediaItemIndex
-            val currentItem =
-              exoPlayer
-                .currentMediaItem
-                ?.localConfiguration
-                ?.tag as? DetailedItem
-
-            if (null == currentItem) {
-              return
-            }
 
             if (isTrackAvailable(exoPlayer.currentMediaItemIndex)) {
               return

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackService.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackService.kt
@@ -260,8 +260,7 @@ class PlaybackService : MediaLibraryService() {
                 .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK_CHAPTER)
                 .setExtras(Bundle().apply { putLong(CHAPTER_START_MS, (chapter.start * 1000).toLong()) })
                 .build(),
-            ).setTag(book)
-            .build()
+            ).build()
         }
       return MediaItemsWithStartPosition(chapterMediaItems, chapterIndex, (chapterOffset * 1000).toLong())
     }


### PR DESCRIPTION
The LLM flagged this and I figured I'd clean up. Details follow:

The skip-unavailable-track handling in `PlaybackNavigationService.onPositionDiscontinuity` never ran. Two independent reasons:

**1. The `DetailedItem` tag never existed.** `PlaybackService.bookToChapterMediaItems` calls `.setTag(book)` but never `setUri`. In Media3, `Builder.setTag` only writes into `LocalConfiguration`, and `build()` creates one only when `uri != null`:

```java
if (uri != null) { localConfiguration = new LocalConfiguration(uri, ..., tag, ...); }
```

So the tag was discarded at construction and `currentMediaItem?.localConfiguration?.tag as? DetailedItem` was always null, returning early every time.

**2. `LissenMediaSourceFactory` also dropped `mediaId` and `requestMetadata`.** `BasePlayer.getCurrentMediaItem()` and `getMediaItemAt(i)` both read `getCurrentTimeline().getWindow(i, window).mediaItem`, which comes from the `MediaSource` the factory returned, not from the item passed to `setMediaItems`. `ClippingMediaSource` delegates `getMediaItem()` to its child, and `ConcatenatingMediaSource2`'s window uses the item from `Builder.setMediaItem()`. The factory forwarded only `mediaMetadata`, so `mediaId` and the `FILE_SEGMENTS` extras were lost, and `isTrackAvailable` returned `false` for every track.

The existing `mediaMetadata` forwarding is what kept `PlaybackSynchronizationService.getProgress` working via `CHAPTER_START_MS`, which is good evidence this behaviour was already hit once empirically.

**Both parts have to be fixed together.** Restoring only the tag would let the guard pass while `isTrackAvailable` still reported everything unavailable, so `findAvailableTrackIndex` would return `null` and the player would `pause()` + `cancelSynchronization()` on every chapter transition.

## Changes

- `LissenMediaSourceFactory` carries the chapter item's identity onto the sources it builds: the single-segment item is now `mediaItem.buildUpon().setUri(...)`, and the original `mediaItem` is passed straight to `ConcatenatingMediaSource2.Builder.setMediaItem`. This also removes the hand-rolled rebuild that was there before, so the factory is slightly smaller than it was.
- `PlaybackNavigationService` drops the `DetailedItem` guard. It was a redundant "is this one of our items?" check, the value was never used, and the `mediaId` parse in `isTrackAvailable` already serves that purpose.
- `PlaybackService` drops the no-op `.setTag(book)`.
- Comments added at both sites recording why the identity must survive, and the known limitation below.

## Scope and behaviour

`LissenMediaProvider.provideFileUri` only fails when force-cache is on and the file is absent from disk, so streaming users keep `isTrackAvailable == true` and see no change. Only offline users with partly downloaded books get the newly live skip behaviour.

Chapters with zero file segments become `SilenceMediaSource`, whose `mediaId` is fixed, so they read as unavailable and get skipped. That seems right for an empty chapter.

`getMediaItemAt(i).mediaId` is now `chapter:<bookId>:<n>` rather than the empty default, so it becomes visible to media controllers. `MediaLibrarySessionCallback` and `MediaRepository` do not read `mediaId` from the player, so no regression is expected there.

Deliberately left alone, to keep this focused:

- An unavailable **first** chapter is still not skipped and fails on load. Setting the playlist raises `onTimelineChanged`, not a discontinuity, so it never reaches this callback.
- `onPositionDiscontinuity` still ignores `reason`, so seek-triggered skipping stays in place.
- The pre-existing direction bug, where a backward wrap from index 0 to N-1 is classified `FORWARD`, is untouched. It is unreachable without repeat mode.
- The main-thread `File.exists()` in `isTrackAvailable` is untouched. Worst case is one stat per clip during a skip search.

## Testing

`:app:testDebugUnitTest`, `:app:assembleDebug`, `:app:assembleDebugAndroidTest` and `:app:lintKotlin` all pass locally; 858 unit tests, no failures.

Two tests added to `LissenMediaSourceFactoryTest` covering the single-segment and multi-segment paths. The instrumented tests were **not** executed locally, as no emulator was available, so they run for the first time in CI here.
