### PR TITLE
Add option to show book time instead of chapter time

### DIFF
--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
@@ -1,5 +1,6 @@
 package org.grakovne.lissen.playback
 
+import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -43,6 +44,13 @@ class LissenMediaSourceFactoryTest {
     assertEquals(mediaItem.mediaId, reportedItem.mediaId)
     assertEquals(mediaItem.requestMetadata, reportedItem.requestMetadata)
     assertEquals(mediaItem.mediaMetadata, reportedItem.mediaMetadata)
+    assertEquals(500_000L, reportedItem.mediaMetadata.extras?.getLong(CHAPTER_START_MS))
+    val reportedSegments =
+      reportedItem.requestMetadata.extras?.let {
+        BundleCompat.getParcelableArrayList(it, FILE_SEGMENTS, FileClip::class.java)
+      }
+    assertNotNull(reportedSegments)
+    assertEquals(1, reportedSegments!!.size)
   }
 
   @Test
@@ -60,6 +68,13 @@ class LissenMediaSourceFactoryTest {
     assertEquals(mediaItem.mediaId, reportedItem.mediaId)
     assertEquals(mediaItem.requestMetadata, reportedItem.requestMetadata)
     assertEquals(mediaItem.mediaMetadata, reportedItem.mediaMetadata)
+    assertEquals(500_000L, reportedItem.mediaMetadata.extras?.getLong(CHAPTER_START_MS))
+    val reportedSegments =
+      reportedItem.requestMetadata.extras?.let {
+        BundleCompat.getParcelableArrayList(it, FILE_SEGMENTS, FileClip::class.java)
+      }
+    assertNotNull(reportedSegments)
+    assertEquals(2, reportedSegments!!.size)
   }
 
   private fun chapterMediaItem(segments: ArrayList<FileClip>): MediaItem =

--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
@@ -19,6 +19,13 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
+// The factory is given a DataSource.Factory rather than a DefaultMediaSourceFactory so that these
+// tests assert on the MediaSource the factory returns, which is what BasePlayer.getCurrentMediaItem
+// reads via the timeline window. Mocking the inner factory would only prove what we passed into it.
+//
+// The extras assertions are not redundant with the enclosing metadata assertions: in Media3 1.11.0,
+// MediaMetadata.equals and RequestMetadata.equals only check whether extras is null, never its
+// contents. FILE_SEGMENTS and CHAPTER_START_MS have to be checked by hand.
 class LissenMediaSourceFactoryTest {
   private lateinit var lissenMediaSourceFactory: LissenMediaSourceFactory
 

--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
@@ -5,12 +5,15 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import org.grakovne.lissen.content.ExternalCoverProvider
 import org.grakovne.lissen.playback.service.FileClip
 import org.grakovne.lissen.playback.service.LissenMediaSourceFactory
 import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_START_MS
 import org.grakovne.lissen.playback.service.PlaybackService.Companion.FILE_SEGMENTS
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
@@ -29,30 +32,60 @@ class LissenMediaSourceFactoryTest {
 
   @Test
   fun no_exception_thrown_if_no_files() {
-    val mediaSource =
-      lissenMediaSourceFactory.createMediaSource(
-        MediaItem
-          .Builder()
-          .setMediaId(LissenMediaSourceFactory.MediaId("book-id", 5).toString())
-          .setRequestMetadata(
-            MediaItem.RequestMetadata
-              .Builder()
-              .setExtras(bundleOf(FILE_SEGMENTS to arrayListOf<FileClip>()))
-              .build(),
-          ).setMediaMetadata(
-            MediaMetadata
-              .Builder()
-              .setAlbumTitle("title")
-              .setTitle("chapter")
-              .setArtist("book")
-              .setIsBrowsable(false)
-              .setIsPlayable(true)
-              .setArtworkUri(ExternalCoverProvider.bookCoverUri("book-id"))
-              .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK_CHAPTER)
-              .setExtras(bundleOf(CHAPTER_START_MS to (500 * 1000).toLong()))
-              .build(),
-          ).build(),
-      )
+    val mediaSource = lissenMediaSourceFactory.createMediaSource(chapterMediaItem(arrayListOf()))
     assertNotNull(mediaSource)
   }
+
+  @Test
+  fun media_id_and_request_metadata_preserved_for_single_segment_chapter() {
+    val capturedItem = slot<MediaItem>()
+    every { mediaSourceFactory.createMediaSource(capture(capturedItem)) } returns mockk(relaxed = true)
+
+    val mediaItem = chapterMediaItem(arrayListOf(FileClip("file-1", 0.0, 30.0)))
+    lissenMediaSourceFactory.createMediaSource(mediaItem)
+
+    assertEquals(mediaItem.mediaId, capturedItem.captured.mediaId)
+    assertEquals(mediaItem.requestMetadata, capturedItem.captured.requestMetadata)
+    assertEquals(mediaItem.mediaMetadata, capturedItem.captured.mediaMetadata)
+  }
+
+  @Test
+  fun media_id_and_request_metadata_preserved_for_multi_segment_chapter() {
+    val mediaItem =
+      chapterMediaItem(
+        arrayListOf(
+          FileClip("file-1", 0.0, 30.0),
+          FileClip("file-2", 30.0, 60.0),
+        ),
+      )
+
+    val reportedItem = lissenMediaSourceFactory.createMediaSource(mediaItem).mediaItem
+
+    assertEquals(mediaItem.mediaId, reportedItem.mediaId)
+    assertEquals(mediaItem.requestMetadata, reportedItem.requestMetadata)
+    assertEquals(mediaItem.mediaMetadata, reportedItem.mediaMetadata)
+  }
+
+  private fun chapterMediaItem(segments: ArrayList<FileClip>): MediaItem =
+    MediaItem
+      .Builder()
+      .setMediaId(LissenMediaSourceFactory.MediaId("book-id", 5).toString())
+      .setRequestMetadata(
+        MediaItem.RequestMetadata
+          .Builder()
+          .setExtras(bundleOf(FILE_SEGMENTS to segments))
+          .build(),
+      ).setMediaMetadata(
+        MediaMetadata
+          .Builder()
+          .setAlbumTitle("title")
+          .setTitle("chapter")
+          .setArtist("book")
+          .setIsBrowsable(false)
+          .setIsPlayable(true)
+          .setArtworkUri(ExternalCoverProvider.bookCoverUri("book-id"))
+          .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK_CHAPTER)
+          .setExtras(bundleOf(CHAPTER_START_MS to (500 * 1000).toLong()))
+          .build(),
+      ).build()
 }

--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/LissenMediaSourceFactoryTest.kt
@@ -3,13 +3,11 @@ package org.grakovne.lissen.playback
 import androidx.core.os.bundleOf
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
-import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import org.grakovne.lissen.content.ExternalCoverProvider
 import org.grakovne.lissen.playback.service.FileClip
+import org.grakovne.lissen.playback.service.LissenDataSourceFactory
 import org.grakovne.lissen.playback.service.LissenMediaSourceFactory
 import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_START_MS
 import org.grakovne.lissen.playback.service.PlaybackService.Companion.FILE_SEGMENTS
@@ -21,13 +19,14 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class LissenMediaSourceFactoryTest {
-  private lateinit var mediaSourceFactory: DefaultMediaSourceFactory
   private lateinit var lissenMediaSourceFactory: LissenMediaSourceFactory
+
+  private lateinit var lissenDataSourceFactory: LissenDataSourceFactory
 
   @Before
   fun setUp() {
-    mediaSourceFactory = mockk(relaxed = true)
-    lissenMediaSourceFactory = LissenMediaSourceFactory(mediaSourceFactory)
+    lissenDataSourceFactory = mockk(relaxed = true)
+    lissenMediaSourceFactory = LissenMediaSourceFactory(lissenDataSourceFactory)
   }
 
   @Test
@@ -38,15 +37,12 @@ class LissenMediaSourceFactoryTest {
 
   @Test
   fun media_id_and_request_metadata_preserved_for_single_segment_chapter() {
-    val capturedItem = slot<MediaItem>()
-    every { mediaSourceFactory.createMediaSource(capture(capturedItem)) } returns mockk(relaxed = true)
-
     val mediaItem = chapterMediaItem(arrayListOf(FileClip("file-1", 0.0, 30.0)))
-    lissenMediaSourceFactory.createMediaSource(mediaItem)
+    val reportedItem = lissenMediaSourceFactory.createMediaSource(mediaItem).mediaItem
 
-    assertEquals(mediaItem.mediaId, capturedItem.captured.mediaId)
-    assertEquals(mediaItem.requestMetadata, capturedItem.captured.requestMetadata)
-    assertEquals(mediaItem.mediaMetadata, capturedItem.captured.mediaMetadata)
+    assertEquals(mediaItem.mediaId, reportedItem.mediaId)
+    assertEquals(mediaItem.requestMetadata, reportedItem.requestMetadata)
+    assertEquals(mediaItem.mediaMetadata, reportedItem.mediaMetadata)
   }
 
   @Test

--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallbackTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallbackTest.kt
@@ -29,6 +29,7 @@ import org.grakovne.lissen.domain.BookFile
 import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.MediaProgress
 import org.grakovne.lissen.domain.PlayingChapter
+import org.grakovne.lissen.persistence.preferences.LibraryPreferences
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
 import org.grakovne.lissen.playback.service.FileClip
 import org.grakovne.lissen.playback.service.PlaybackService.Companion.FILE_SEGMENTS
@@ -48,6 +49,7 @@ import java.util.concurrent.TimeUnit
 class MediaLibrarySessionCallbackTest {
   private lateinit var context: Context
   private lateinit var preferences: PlaybackPreferences
+  private lateinit var libraryPreferences: LibraryPreferences
   private lateinit var mediaRepository: MediaRepository
   private lateinit var lissenMediaProvider: LissenMediaProvider
   private lateinit var libraryTree: MediaLibraryTree
@@ -61,6 +63,7 @@ class MediaLibrarySessionCallbackTest {
   fun setUp() {
     context = ApplicationProvider.getApplicationContext()
     preferences = mockk(relaxed = true)
+    libraryPreferences = mockk(relaxed = true)
     mediaRepository = mockk(relaxed = true)
     lissenMediaProvider = mockk(relaxed = true)
     libraryTree = mockk(relaxed = true)
@@ -73,6 +76,7 @@ class MediaLibrarySessionCallbackTest {
       MediaLibrarySessionCallback(
         context,
         preferences,
+        libraryPreferences,
         mediaRepository,
         lissenMediaProvider,
         libraryTree,

--- a/app/src/main/kotlin/org/grakovne/lissen/persistence/preferences/PlaybackPreferences.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/persistence/preferences/PlaybackPreferences.kt
@@ -48,9 +48,9 @@ class PlaybackPreferences
 
     fun saveSoftwareCodecsEnabled(value: Boolean) = store.putBoolean(KEY_SOFTWARE_CODECS, value)
 
-    fun getShowBookTimeRemaining(): Boolean = store.getBoolean(KEY_SHOW_BOOK_TIME_REMAINING, false)
+    fun getShowBookTime(): Boolean = store.getBoolean(KEY_SHOW_BOOK_TIME_REMAINING, false)
 
-    fun saveShowBookTimeRemaining(value: Boolean) = store.putBoolean(KEY_SHOW_BOOK_TIME_REMAINING, value)
+    fun saveShowBookTime(value: Boolean) = store.putBoolean(KEY_SHOW_BOOK_TIME_REMAINING, value)
 
     fun getAudioFocusLossPolicy(): AudioFocusLossPolicy =
       store

--- a/app/src/main/kotlin/org/grakovne/lissen/persistence/preferences/PlaybackPreferences.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/persistence/preferences/PlaybackPreferences.kt
@@ -48,6 +48,10 @@ class PlaybackPreferences
 
     fun saveSoftwareCodecsEnabled(value: Boolean) = store.putBoolean(KEY_SOFTWARE_CODECS, value)
 
+    fun getShowBookTimeRemaining(): Boolean = store.getBoolean(KEY_SHOW_BOOK_TIME_REMAINING, false)
+
+    fun saveShowBookTimeRemaining(value: Boolean) = store.putBoolean(KEY_SHOW_BOOK_TIME_REMAINING, value)
+
     fun getAudioFocusLossPolicy(): AudioFocusLossPolicy =
       store
         .getString(KEY_AUDIO_FOCUS_LOSS_POLICY)
@@ -182,6 +186,7 @@ class PlaybackPreferences
       private const val KEY_PREFERRED_PLAYBACK_SPEED = "preferred_playback_speed"
       private const val KEY_PREFERRED_SEEK_TIME = "preferred_seek_time"
       private const val KEY_SOFTWARE_CODECS = "software_codecs"
+      private const val KEY_SHOW_BOOK_TIME_REMAINING = "show_book_time_remaining"
       private const val KEY_AUDIO_FOCUS_LOSS_POLICY = "audio_focus_loss_policy"
       private const val KEY_EQUALIZER = "equalizer"
       private const val KEY_DEFAULT_SLEEP_TIMER = "default_sleep_timer"

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayer.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayer.kt
@@ -4,9 +4,6 @@ import androidx.media3.common.C
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import org.grakovne.lissen.domain.DetailedItem
-import org.grakovne.lissen.playback.service.LissenMediaSourceFactory
-import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_START_MS
 import org.grakovne.lissen.playback.service.calculateChapterIndexAndPosition
 
 /**
@@ -14,13 +11,14 @@ import org.grakovne.lissen.playback.service.calculateChapterIndexAndPosition
  * chapter) into book-scoped values for whatever consumes the player through the media session:
  * Android Auto, the system media notification, the lock screen and Wear.
  *
- * The active book comes from the [BookTimeScope] snapshot taken when the playlist was built,
- * cross-checked against the mediaId of the current timeline item, which LissenMediaSourceFactory
- * carries over from the playlist item into the sources it builds. The same check gates position,
- * duration and the seek reverse mapping, so they can never disagree about the scope: when the
- * snapshot book does not match the current item, everything falls through to chapter values.
- * Toggling the setting therefore applies the next time a book is prepared, never mid-book.
- * Everything else keeps receiving the raw player and keeps working on chapter values.
+ * Book scope is decided by the single shared predicate [resolveBookTimeTranslation]: the
+ * [BookTimeScope] snapshot book must match the mediaId of the current timeline item (which
+ * LissenMediaSourceFactory carries over from the playlist item into the sources it builds) and
+ * the item must carry a valid CHAPTER_START_MS extra. The same predicate gates position, duration
+ * and the seek reverse mapping, and [MediaRepository] resolves the controller's view of the same
+ * timeline through the same function, so position and duration can never disagree about the
+ * scope. Toggling the setting applies the next time a book is prepared, never mid-book. Everything
+ * else keeps receiving the raw player and keeps working on chapter values.
  */
 @UnstableApi
 class BookTimeForwardingPlayer(
@@ -39,56 +37,50 @@ class BookTimeForwardingPlayer(
   override fun getContentDuration(): Long = translateBookDuration(super.getContentDuration())
 
   override fun seekTo(positionMs: Long) {
-    val book = activeBook()
+    val translation = translation()
+    val book =
+      translation?.book ?: run {
+        super.seekTo(positionMs)
+        return
+      }
 
-    if (book == null) {
-      super.seekTo(positionMs)
+    val totalDurationMs = (book.chapters.sumOf { it.duration } * 1000).toLong()
+    val clampedPositionMs = positionMs.coerceIn(0L, totalDurationMs)
+
+    // At or past the book end, seek to the end of the last chapter so scrubbing to the far
+    // right ends the book; calculateChapterIndexAndPosition would map that to the start of
+    // the last chapter, which is deliberate for resume but wrong for scrubbing.
+    if (clampedPositionMs >= totalDurationMs) {
+      val lastIndex = book.chapters.lastIndex
+      super.seekTo(lastIndex, (book.chapters[lastIndex].duration * 1000).toLong())
       return
     }
 
-    val (chapterIndex, chapterPosition) = calculateChapterIndexAndPosition(book, positionMs / 1000.0)
+    val (chapterIndex, chapterPosition) = calculateChapterIndexAndPosition(book, clampedPositionMs / 1000.0)
 
     if (chapterIndex !in book.chapters.indices) {
-      super.seekTo(positionMs)
+      super.seekTo(clampedPositionMs)
       return
     }
 
     super.seekTo(chapterIndex, (chapterPosition * 1000).toLong())
   }
 
-  private fun activeBook(): DetailedItem? {
-    val book = BookTimeScope.book ?: return null
-
-    val bookId =
-      currentMediaItem
-        ?.mediaId
-        ?.let(LissenMediaSourceFactory.MediaId::fromString)
-        ?.bookId
-        ?: return null
-
-    return book.takeIf { it.id == bookId }
-  }
+  private fun translation(): BookTimeTranslation? = resolveBookTimeTranslation(currentMediaItem, BookTimeScope.book)
 
   private fun translateChapterPosition(chapterPositionMs: Long): Long {
     if (chapterPositionMs == C.TIME_UNSET) return chapterPositionMs
-    if (activeBook() == null) return chapterPositionMs
 
-    val chapterStartMs =
-      currentMediaItem
-        ?.mediaMetadata
-        ?.extras
-        ?.getLong(CHAPTER_START_MS, -1)
-        ?.takeIf { it >= 0 }
-        ?: return chapterPositionMs
+    val translation = translation() ?: return chapterPositionMs
 
-    return chapterStartMs + chapterPositionMs
+    return translation.chapterStartMs + chapterPositionMs
   }
 
   private fun translateBookDuration(chapterDurationMs: Long): Long {
     if (chapterDurationMs == C.TIME_UNSET) return chapterDurationMs
 
-    val book = activeBook() ?: return chapterDurationMs
+    val translation = translation() ?: return chapterDurationMs
 
-    return (book.chapters.sumOf { it.duration } * 1000).toLong()
+    return (translation.book.chapters.sumOf { it.duration } * 1000).toLong()
   }
 }

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayer.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayer.kt
@@ -3,6 +3,7 @@ package org.grakovne.lissen.playback
 import androidx.media3.common.C
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
 import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.LibraryType
 import org.grakovne.lissen.persistence.preferences.LibraryPreferences
@@ -27,6 +28,7 @@ import org.grakovne.lissen.playback.service.calculateChapterIndexAndPosition
  * Android Auto or the notification showing the previous scope until the next such event. This is
  * an accepted limitation.
  */
+@UnstableApi
 class BookTimeForwardingPlayer(
   player: Player,
   private val playbackPreferences: PlaybackPreferences,

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayer.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayer.kt
@@ -5,7 +5,6 @@ import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import org.grakovne.lissen.domain.DetailedItem
-import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
 import org.grakovne.lissen.playback.service.LissenMediaSourceFactory
 import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_START_MS
 import org.grakovne.lissen.playback.service.calculateChapterIndexAndPosition
@@ -15,20 +14,17 @@ import org.grakovne.lissen.playback.service.calculateChapterIndexAndPosition
  * chapter) into book-scoped values for whatever consumes the player through the media session:
  * Android Auto, the system media notification, the lock screen and Wear.
  *
- * The active book is identified from the mediaId of the current timeline item, which
- * LissenMediaSourceFactory carries over from the playlist item into the sources it builds.
- *
- * The translation is applied per call, but only while the book-time scope snapshot
- * [BookTimeScope.isBookTimeEnabled] is set. The snapshot is written once when a playlist is
- * built, so position, duration and the seek reverse mapping always agree on the same scope, and
- * MediaRepository reads the same value. Toggling the setting therefore applies the next time a
- * book is prepared, never mid-book. Everything else keeps receiving the raw player and keeps
- * working on chapter values.
+ * The active book comes from the [BookTimeScope] snapshot taken when the playlist was built,
+ * cross-checked against the mediaId of the current timeline item, which LissenMediaSourceFactory
+ * carries over from the playlist item into the sources it builds. The same check gates position,
+ * duration and the seek reverse mapping, so they can never disagree about the scope: when the
+ * snapshot book does not match the current item, everything falls through to chapter values.
+ * Toggling the setting therefore applies the next time a book is prepared, never mid-book.
+ * Everything else keeps receiving the raw player and keeps working on chapter values.
  */
 @UnstableApi
 class BookTimeForwardingPlayer(
   player: Player,
-  private val playbackPreferences: PlaybackPreferences,
 ) : ForwardingPlayer(player) {
   override fun getCurrentPosition(): Long = translateChapterPosition(super.getCurrentPosition())
 
@@ -61,9 +57,7 @@ class BookTimeForwardingPlayer(
   }
 
   private fun activeBook(): DetailedItem? {
-    if (!BookTimeScope.isBookTimeEnabled) return null
-
-    val book = playbackPreferences.getPlayingItem()?.takeIf { it.chapters.isNotEmpty() } ?: return null
+    val book = BookTimeScope.book ?: return null
 
     val bookId =
       currentMediaItem
@@ -77,7 +71,7 @@ class BookTimeForwardingPlayer(
 
   private fun translateChapterPosition(chapterPositionMs: Long): Long {
     if (chapterPositionMs == C.TIME_UNSET) return chapterPositionMs
-    if (!BookTimeScope.isBookTimeEnabled) return chapterPositionMs
+    if (activeBook() == null) return chapterPositionMs
 
     val chapterStartMs =
       currentMediaItem

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayer.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayer.kt
@@ -1,0 +1,106 @@
+package org.grakovne.lissen.playback
+
+import androidx.media3.common.C
+import androidx.media3.common.ForwardingPlayer
+import androidx.media3.common.Player
+import org.grakovne.lissen.domain.DetailedItem
+import org.grakovne.lissen.domain.LibraryType
+import org.grakovne.lissen.persistence.preferences.LibraryPreferences
+import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
+import org.grakovne.lissen.playback.service.LissenMediaSourceFactory
+import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_START_MS
+import org.grakovne.lissen.playback.service.calculateChapterIndexAndPosition
+
+/**
+ * Translates the chapter-scoped player values of the ExoPlayer playlist (one MediaItem per
+ * chapter) into book-scoped values for whatever consumes the player through the media session:
+ * Android Auto, the system media notification, the lock screen and Wear.
+ *
+ * The translation is applied per call and only while the book-time setting is enabled and the
+ * active library is a book library, so toggling the setting changes controller behaviour without
+ * rebuilding the session. Everything else keeps receiving the raw player and keeps working on
+ * chapter values.
+ *
+ * Note: reading the preference per getter does not push new values to already-connected
+ * controllers, and the session disables periodic position updates, so controllers only republish
+ * after the next player event (play, pause or seek). Toggling the setting can therefore leave
+ * Android Auto or the notification showing the previous scope until the next such event. This is
+ * an accepted limitation.
+ */
+class BookTimeForwardingPlayer(
+  player: Player,
+  private val playbackPreferences: PlaybackPreferences,
+  private val libraryPreferences: LibraryPreferences,
+) : ForwardingPlayer(player) {
+  override fun getCurrentPosition(): Long = translateChapterPosition(super.getCurrentPosition())
+
+  override fun getContentPosition(): Long = translateChapterPosition(super.getContentPosition())
+
+  override fun getBufferedPosition(): Long = translateChapterPosition(super.getBufferedPosition())
+
+  override fun getContentBufferedPosition(): Long = translateChapterPosition(super.getContentBufferedPosition())
+
+  override fun getDuration(): Long = translateBookDuration(super.getDuration())
+
+  override fun getContentDuration(): Long = translateBookDuration(super.getContentDuration())
+
+  override fun seekTo(positionMs: Long) {
+    val book = activeBook()
+
+    if (book == null) {
+      super.seekTo(positionMs)
+      return
+    }
+
+    val (chapterIndex, chapterPosition) = calculateChapterIndexAndPosition(book, positionMs / 1000.0)
+
+    if (chapterIndex !in book.chapters.indices) {
+      super.seekTo(positionMs)
+      return
+    }
+
+    super.seekTo(chapterIndex, (chapterPosition * 1000).toLong())
+  }
+
+  private fun isBookTimeEnabled(): Boolean =
+    playbackPreferences.getShowBookTime() &&
+      libraryPreferences.getPreferredLibrary()?.type == LibraryType.LIBRARY
+
+  private fun activeBook(): DetailedItem? {
+    if (!isBookTimeEnabled()) return null
+
+    val book = playbackPreferences.getPlayingItem()?.takeIf { it.chapters.isNotEmpty() } ?: return null
+
+    val bookId =
+      currentMediaItem
+        ?.mediaId
+        ?.let(LissenMediaSourceFactory.MediaId::fromString)
+        ?.bookId
+        ?: return null
+
+    return book.takeIf { it.id == bookId }
+  }
+
+  private fun translateChapterPosition(chapterPositionMs: Long): Long {
+    if (chapterPositionMs == C.TIME_UNSET) return chapterPositionMs
+    if (!isBookTimeEnabled()) return chapterPositionMs
+
+    val chapterStartMs =
+      currentMediaItem
+        ?.mediaMetadata
+        ?.extras
+        ?.getLong(CHAPTER_START_MS, -1)
+        ?.takeIf { it >= 0 }
+        ?: return chapterPositionMs
+
+    return chapterStartMs + chapterPositionMs
+  }
+
+  private fun translateBookDuration(chapterDurationMs: Long): Long {
+    if (chapterDurationMs == C.TIME_UNSET) return chapterDurationMs
+
+    val book = activeBook() ?: return chapterDurationMs
+
+    return (book.chapters.sumOf { it.duration } * 1000).toLong()
+  }
+}

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayer.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayer.kt
@@ -5,8 +5,6 @@ import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import org.grakovne.lissen.domain.DetailedItem
-import org.grakovne.lissen.domain.LibraryType
-import org.grakovne.lissen.persistence.preferences.LibraryPreferences
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
 import org.grakovne.lissen.playback.service.LissenMediaSourceFactory
 import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_START_MS
@@ -17,22 +15,20 @@ import org.grakovne.lissen.playback.service.calculateChapterIndexAndPosition
  * chapter) into book-scoped values for whatever consumes the player through the media session:
  * Android Auto, the system media notification, the lock screen and Wear.
  *
- * The translation is applied per call and only while the book-time setting is enabled and the
- * active library is a book library, so toggling the setting changes controller behaviour without
- * rebuilding the session. Everything else keeps receiving the raw player and keeps working on
- * chapter values.
+ * The active book is identified from the mediaId of the current timeline item, which
+ * LissenMediaSourceFactory carries over from the playlist item into the sources it builds.
  *
- * Note: reading the preference per getter does not push new values to already-connected
- * controllers, and the session disables periodic position updates, so controllers only republish
- * after the next player event (play, pause or seek). Toggling the setting can therefore leave
- * Android Auto or the notification showing the previous scope until the next such event. This is
- * an accepted limitation.
+ * The translation is applied per call, but only while the book-time scope snapshot
+ * [BookTimeScope.isBookTimeEnabled] is set. The snapshot is written once when a playlist is
+ * built, so position, duration and the seek reverse mapping always agree on the same scope, and
+ * MediaRepository reads the same value. Toggling the setting therefore applies the next time a
+ * book is prepared, never mid-book. Everything else keeps receiving the raw player and keeps
+ * working on chapter values.
  */
 @UnstableApi
 class BookTimeForwardingPlayer(
   player: Player,
   private val playbackPreferences: PlaybackPreferences,
-  private val libraryPreferences: LibraryPreferences,
 ) : ForwardingPlayer(player) {
   override fun getCurrentPosition(): Long = translateChapterPosition(super.getCurrentPosition())
 
@@ -64,12 +60,8 @@ class BookTimeForwardingPlayer(
     super.seekTo(chapterIndex, (chapterPosition * 1000).toLong())
   }
 
-  private fun isBookTimeEnabled(): Boolean =
-    playbackPreferences.getShowBookTime() &&
-      libraryPreferences.getPreferredLibrary()?.type == LibraryType.LIBRARY
-
   private fun activeBook(): DetailedItem? {
-    if (!isBookTimeEnabled()) return null
+    if (!BookTimeScope.isBookTimeEnabled) return null
 
     val book = playbackPreferences.getPlayingItem()?.takeIf { it.chapters.isNotEmpty() } ?: return null
 
@@ -85,7 +77,7 @@ class BookTimeForwardingPlayer(
 
   private fun translateChapterPosition(chapterPositionMs: Long): Long {
     if (chapterPositionMs == C.TIME_UNSET) return chapterPositionMs
-    if (!isBookTimeEnabled()) return chapterPositionMs
+    if (!BookTimeScope.isBookTimeEnabled) return chapterPositionMs
 
     val chapterStartMs =
       currentMediaItem

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeScope.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeScope.kt
@@ -1,6 +1,8 @@
 package org.grakovne.lissen.playback
 
+import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
 import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.LibraryType
 import org.grakovne.lissen.domain.PlayingChapter
@@ -66,6 +68,7 @@ data class BookTimeTranslation(
  * a missing chapter offset — resolves to null, and both sides fail closed to chapter scope
  * together.
  */
+@OptIn(UnstableApi::class)
 fun resolveBookTimeTranslation(
   mediaItem: MediaItem?,
   snapshotBook: DetailedItem?,

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeScope.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeScope.kt
@@ -1,25 +1,32 @@
 package org.grakovne.lissen.playback
 
+import androidx.media3.common.MediaItem
 import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.LibraryType
+import org.grakovne.lissen.domain.PlayingChapter
 import org.grakovne.lissen.persistence.preferences.LibraryPreferences
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
+import org.grakovne.lissen.playback.service.LissenMediaSourceFactory
+import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_START_MS
 
 /**
  * Single shared snapshot of the book-time scope decision, taken once when a playlist is built.
  *
- * The snapshot is written from the three places that build a playlist:
- * [PlaybackService.preparePlayback], [MediaLibrarySessionCallback.onSetMediaItems] and
- * [MediaLibrarySessionCallback.onPlaybackResumption]. That includes the resumption path where the
- * request is metadata-only (isForPlayback = false): a playlist is still built there for the queue
- * display, and all readers share the one value, so this is intentional, not a bug. If a playlist
- * is ever built anywhere else, the snapshot must be updated there too; the mediaId cross-check in
- * [BookTimeForwardingPlayer] then falls back to chapter scope rather than translating against a
- * stale book.
+ * The snapshot is written from [PlaybackService.preparePlayback] and
+ * [MediaLibrarySessionCallback.onSetMediaItems], which build playlists, and from
+ * [MediaLibrarySessionCallback.onPlaybackResumption]. The resumption callback also fires for
+ * metadata-only requests (isForPlayback = false, e.g. System UI populating its playback
+ * resumption notification after reboot): media3 does not build a playlist there, it only consumes
+ * the returned item's metadata. The write is then harmless — the next real playlist build rewrites
+ * it, and in the meantime both sides fail closed because the timeline's mediaIds do not change.
+ * If a playlist is ever built anywhere else, the snapshot must be updated there too; the mediaId
+ * cross-check in [resolveBookTimeTranslation] then falls back to chapter scope rather than
+ * translating against a stale book.
  *
- * Everyone that translates player times reads this one value: the media session player (position,
- * duration and seek mappings, via the cross-checked book) and the progress updater in
- * [MediaRepository] (via the book id). Because the value is fixed at playlist build time, none of
+ * Everyone that translates player times goes through the one predicate in
+ * [resolveBookTimeTranslation]: the media session player (position, duration and seek mappings)
+ * and the progress updater in [MediaRepository], which resolves the controller's view of the same
+ * timeline. Because the value is fixed at playlist build time and the predicate is shared, none of
  * them can ever disagree about the scope, and the book-time setting applies when the next
  * playlist is prepared rather than instantly.
  */
@@ -39,5 +46,68 @@ object BookTimeScope {
           playbackPreferences.getShowBookTime() &&
           libraryPreferences.getPreferredLibrary()?.type == LibraryType.LIBRARY
       }
+  }
+}
+
+/**
+ * The resolved book-time translation for a single timeline item: the snapshot book, confirmed
+ * against the item's mediaId, together with the item's chapter start offset.
+ */
+data class BookTimeTranslation(
+  val book: DetailedItem,
+  val chapterStartMs: Long,
+)
+
+/**
+ * The single scope predicate shared by the media session player and [MediaRepository]: book scope
+ * only when the snapshot holds a book whose id matches the current item's mediaId and the item
+ * carries a valid CHAPTER_START_MS extra. Anything else — no snapshot, an unparseable or
+ * mismatched mediaId (including silence-only chapters, whose sources carry their own mediaId), or
+ * a missing chapter offset — resolves to null, and both sides fail closed to chapter scope
+ * together.
+ */
+fun resolveBookTimeTranslation(
+  mediaItem: MediaItem?,
+  snapshotBook: DetailedItem?,
+): BookTimeTranslation? {
+  val book = snapshotBook ?: return null
+
+  val bookId =
+    mediaItem
+      ?.mediaId
+      ?.let(LissenMediaSourceFactory.MediaId::fromString)
+      ?.bookId
+      ?: return null
+
+  if (book.id != bookId) return null
+
+  val chapterStartMs =
+    mediaItem
+      ?.mediaMetadata
+      ?.extras
+      ?.getLong(CHAPTER_START_MS, -1)
+      ?.takeIf { it >= 0 }
+      ?: return null
+
+  return BookTimeTranslation(book, chapterStartMs)
+}
+
+/**
+ * The book-scoped progress value for [MediaRepository.updateProgress]: in book scope the session
+ * player already reports book-scoped positions, so the accumulated chapter offsets would
+ * double-count; in chapter scope they are added.
+ */
+fun bookTimeProgress(
+  translation: BookTimeTranslation?,
+  currentMediaItemIndex: Int,
+  currentPositionMs: Long,
+  chapters: List<PlayingChapter>,
+): Double {
+  val currentFilePosition = currentPositionMs / 1000.0
+
+  return if (translation != null) {
+    currentFilePosition
+  } else {
+    chapters.take(currentMediaItemIndex.coerceIn(0, chapters.size)).sumOf { it.duration } + currentFilePosition
   }
 }

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeScope.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeScope.kt
@@ -1,0 +1,28 @@
+package org.grakovne.lissen.playback
+
+import org.grakovne.lissen.domain.LibraryType
+import org.grakovne.lissen.persistence.preferences.LibraryPreferences
+import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
+
+/**
+ * Single shared snapshot of the book-time scope decision, taken once when a playlist is built.
+ *
+ * Everyone that translates player times reads this one value: the media session player (position,
+ * duration and seek mappings) and the progress updater in [MediaRepository]. Because the value is
+ * fixed at playlist build time, none of them can ever disagree about the scope, and the book-time
+ * setting applies when the next playlist is prepared rather than instantly.
+ */
+object BookTimeScope {
+  @Volatile
+  var isBookTimeEnabled: Boolean = false
+    private set
+
+  fun update(
+    playbackPreferences: PlaybackPreferences,
+    libraryPreferences: LibraryPreferences,
+  ) {
+    isBookTimeEnabled =
+      playbackPreferences.getShowBookTime() &&
+      libraryPreferences.getPreferredLibrary()?.type == LibraryType.LIBRARY
+  }
+}

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeScope.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/BookTimeScope.kt
@@ -1,5 +1,6 @@
 package org.grakovne.lissen.playback
 
+import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.LibraryType
 import org.grakovne.lissen.persistence.preferences.LibraryPreferences
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
@@ -7,22 +8,36 @@ import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
 /**
  * Single shared snapshot of the book-time scope decision, taken once when a playlist is built.
  *
+ * The snapshot is written from the three places that build a playlist:
+ * [PlaybackService.preparePlayback], [MediaLibrarySessionCallback.onSetMediaItems] and
+ * [MediaLibrarySessionCallback.onPlaybackResumption]. That includes the resumption path where the
+ * request is metadata-only (isForPlayback = false): a playlist is still built there for the queue
+ * display, and all readers share the one value, so this is intentional, not a bug. If a playlist
+ * is ever built anywhere else, the snapshot must be updated there too; the mediaId cross-check in
+ * [BookTimeForwardingPlayer] then falls back to chapter scope rather than translating against a
+ * stale book.
+ *
  * Everyone that translates player times reads this one value: the media session player (position,
- * duration and seek mappings) and the progress updater in [MediaRepository]. Because the value is
- * fixed at playlist build time, none of them can ever disagree about the scope, and the book-time
- * setting applies when the next playlist is prepared rather than instantly.
+ * duration and seek mappings, via the cross-checked book) and the progress updater in
+ * [MediaRepository] (via the book id). Because the value is fixed at playlist build time, none of
+ * them can ever disagree about the scope, and the book-time setting applies when the next
+ * playlist is prepared rather than instantly.
  */
 object BookTimeScope {
   @Volatile
-  var isBookTimeEnabled: Boolean = false
+  var book: DetailedItem? = null
     private set
 
   fun update(
+    book: DetailedItem,
     playbackPreferences: PlaybackPreferences,
     libraryPreferences: LibraryPreferences,
   ) {
-    isBookTimeEnabled =
-      playbackPreferences.getShowBookTime() &&
-      libraryPreferences.getPreferredLibrary()?.type == LibraryType.LIBRARY
+    this.book =
+      book.takeIf {
+        it.chapters.isNotEmpty() &&
+          playbackPreferences.getShowBookTime() &&
+          libraryPreferences.getPreferredLibrary()?.type == LibraryType.LIBRARY
+      }
   }
 }

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallback.kt
@@ -238,7 +238,7 @@ class MediaLibrarySessionCallback
                 .foldAsync(
                   onSuccess = {
                     preferences.savePlayingItem(it)
-                    BookTimeScope.update(preferences, libraryPreferences)
+                    BookTimeScope.update(it, preferences, libraryPreferences)
                     playbackSynchronizationService.startPlaybackSynchronization(it)
                     mediaRepository.registerPlayingBook(it)
                     PlaybackService.bookToChapterMediaItems(it)
@@ -277,7 +277,7 @@ class MediaLibrarySessionCallback
             mediaRepository.registerPlayingBook(book)
           }
 
-          BookTimeScope.update(preferences, libraryPreferences)
+          BookTimeScope.update(book, preferences, libraryPreferences)
           PlaybackService.bookToChapterMediaItems(book)
         }
 

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallback.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.grakovne.lissen.channel.common.OperationResult
 import org.grakovne.lissen.content.LissenMediaProvider
 import org.grakovne.lissen.domain.DetailedItem
+import org.grakovne.lissen.persistence.preferences.LibraryPreferences
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
 import org.grakovne.lissen.playback.service.PlaybackService
 import org.grakovne.lissen.playback.service.PlaybackSynchronizationService
@@ -48,6 +49,7 @@ class MediaLibrarySessionCallback
   constructor(
     @param:ApplicationContext private val context: Context,
     private val preferences: PlaybackPreferences,
+    private val libraryPreferences: LibraryPreferences,
     private val mediaRepository: MediaRepository,
     private val lissenMediaProvider: LissenMediaProvider,
     private val libraryTree: MediaLibraryTree,
@@ -236,6 +238,7 @@ class MediaLibrarySessionCallback
                 .foldAsync(
                   onSuccess = {
                     preferences.savePlayingItem(it)
+                    BookTimeScope.update(preferences, libraryPreferences)
                     playbackSynchronizationService.startPlaybackSynchronization(it)
                     mediaRepository.registerPlayingBook(it)
                     PlaybackService.bookToChapterMediaItems(it)
@@ -274,6 +277,7 @@ class MediaLibrarySessionCallback
             mediaRepository.registerPlayingBook(book)
           }
 
+          BookTimeScope.update(preferences, libraryPreferences)
           PlaybackService.bookToChapterMediaItems(book)
         }
 

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionProvider.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionProvider.kt
@@ -10,6 +10,8 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaLibraryService
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.grakovne.lissen.BuildConfig
+import org.grakovne.lissen.persistence.preferences.LibraryPreferences
+import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
 import org.grakovne.lissen.ui.activity.AppActivity
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -22,6 +24,8 @@ class MediaLibrarySessionProvider
     @param:ApplicationContext private val context: Context,
     private val exoPlayer: ExoPlayer,
     private val callback: MediaLibrarySessionCallback,
+    private val playbackPreferences: PlaybackPreferences,
+    private val libraryPreferences: LibraryPreferences,
   ) {
     @OptIn(UnstableApi::class)
     fun provideMediaLibrarySession(mediaLibraryService: MediaLibraryService): MediaLibraryService.MediaLibrarySession {
@@ -46,8 +50,14 @@ class MediaLibrarySessionProvider
             Intent.FLAG_GRANT_PREFIX_URI_PERMISSION,
         )
       }
+      val sessionPlayer =
+        BookTimeForwardingPlayer(
+          player = exoPlayer,
+          playbackPreferences = playbackPreferences,
+          libraryPreferences = libraryPreferences,
+        )
       return MediaLibraryService.MediaLibrarySession
-        .Builder(mediaLibraryService, exoPlayer, callback)
+        .Builder(mediaLibraryService, sessionPlayer, callback)
         .setSessionActivity(
           PendingIntent.getActivity(
             context,

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionProvider.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionProvider.kt
@@ -10,7 +10,6 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaLibraryService
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.grakovne.lissen.BuildConfig
-import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
 import org.grakovne.lissen.ui.activity.AppActivity
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -23,7 +22,6 @@ class MediaLibrarySessionProvider
     @param:ApplicationContext private val context: Context,
     private val exoPlayer: ExoPlayer,
     private val callback: MediaLibrarySessionCallback,
-    private val playbackPreferences: PlaybackPreferences,
   ) {
     @OptIn(UnstableApi::class)
     fun provideMediaLibrarySession(mediaLibraryService: MediaLibraryService): MediaLibraryService.MediaLibrarySession {
@@ -48,11 +46,7 @@ class MediaLibrarySessionProvider
             Intent.FLAG_GRANT_PREFIX_URI_PERMISSION,
         )
       }
-      val sessionPlayer =
-        BookTimeForwardingPlayer(
-          player = exoPlayer,
-          playbackPreferences = playbackPreferences,
-        )
+      val sessionPlayer = BookTimeForwardingPlayer(player = exoPlayer)
       return MediaLibraryService.MediaLibrarySession
         .Builder(mediaLibraryService, sessionPlayer, callback)
         .setSessionActivity(

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionProvider.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionProvider.kt
@@ -10,7 +10,6 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaLibraryService
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.grakovne.lissen.BuildConfig
-import org.grakovne.lissen.persistence.preferences.LibraryPreferences
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
 import org.grakovne.lissen.ui.activity.AppActivity
 import javax.inject.Inject
@@ -25,7 +24,6 @@ class MediaLibrarySessionProvider
     private val exoPlayer: ExoPlayer,
     private val callback: MediaLibrarySessionCallback,
     private val playbackPreferences: PlaybackPreferences,
-    private val libraryPreferences: LibraryPreferences,
   ) {
     @OptIn(UnstableApi::class)
     fun provideMediaLibrarySession(mediaLibraryService: MediaLibraryService): MediaLibraryService.MediaLibrarySession {
@@ -54,7 +52,6 @@ class MediaLibrarySessionProvider
         BookTimeForwardingPlayer(
           player = exoPlayer,
           playbackPreferences = playbackPreferences,
-          libraryPreferences = libraryPreferences,
         )
       return MediaLibraryService.MediaLibrarySession
         .Builder(mediaLibraryService, sessionPlayer, callback)

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaModule.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaModule.kt
@@ -92,16 +92,14 @@ object MediaModule {
         ).setRenderersFactory(renderersFactory)
         .setMediaSourceFactory(
           LissenMediaSourceFactory(
-            mediaSourceFactory =
-              DefaultMediaSourceFactory(
-                LissenDataSourceFactory(
-                  baseContext = context,
-                  mediaCache = mediaCache,
-                  requestHeadersProvider = requestHeadersProvider,
-                  session = sessionPreferences,
-                  connection = connectionPreferences,
-                  mediaProvider = mediaProvider,
-                ),
+            dataSourceFactory =
+              LissenDataSourceFactory(
+                baseContext = context,
+                mediaCache = mediaCache,
+                requestHeadersProvider = requestHeadersProvider,
+                session = sessionPreferences,
+                connection = connectionPreferences,
+                mediaProvider = mediaProvider,
               ),
           ),
         ).build()

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
@@ -441,22 +441,22 @@ class MediaRepository
     }
 
     private fun updateProgress(detailedItem: DetailedItem) {
-      val currentIndex = mediaController.currentMediaItemIndex
-      val chapters = detailedItem.chapters
-      val accumulated = chapters.take(currentIndex.coerceIn(0, chapters.size)).sumOf { it.duration }
-      val currentFilePosition = mediaController.currentPosition / 1000.0
+      // The controller mirrors the session timeline, so its current item carries the same
+      // mediaId and extras the session player resolves against: both sides share the one
+      // scope predicate and fail closed to chapter scope together.
+      val translation =
+        resolveBookTimeTranslation(
+          mediaItem = mediaController.currentMediaItem,
+          snapshotBook = BookTimeScope.book,
+        )
 
-      // In book scope the session player already reports book-scoped positions, so the
-      // accumulated chapter offsets would double-count. The snapshot book must match the
-      // playing book, exactly like the player's own scope check, so both fail closed to
-      // chapter scope together.
-      val newPosition =
-        if (BookTimeScope.book?.id == detailedItem.id) {
-          currentFilePosition
-        } else {
-          accumulated + currentFilePosition
-        }
-      _totalPosition.value = newPosition
+      _totalPosition.value =
+        bookTimeProgress(
+          translation = translation,
+          currentMediaItemIndex = mediaController.currentMediaItemIndex,
+          currentPositionMs = mediaController.currentPosition,
+          chapters = detailedItem.chapters,
+        )
       updateCurrentTrackData()
     }
 

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
@@ -13,6 +13,7 @@ import androidx.media3.session.SessionToken
 import com.google.common.util.concurrent.FutureCallback
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.MoreExecutors
+import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -50,7 +51,7 @@ class MediaRepository
     private val mediaChannel: LissenMediaProvider,
     private val eventBus: PlaybackEventBus,
     private val defaultTimerActivator: DefaultTimerActivator,
-    private val exoPlayer: ExoPlayer,
+    private val exoPlayer: Lazy<ExoPlayer>,
   ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private lateinit var mediaController: MediaController
@@ -443,10 +444,11 @@ class MediaRepository
     }
 
     private fun updateProgress(detailedItem: DetailedItem) {
-      val currentIndex = exoPlayer.currentMediaItemIndex
+      val player = exoPlayer.get()
+      val currentIndex = player.currentMediaItemIndex
       val chapters = detailedItem.chapters
       val accumulated = chapters.take(currentIndex.coerceIn(0, chapters.size)).sumOf { it.duration }
-      val currentFilePosition = exoPlayer.currentPosition / 1000.0
+      val currentFilePosition = player.currentPosition / 1000.0
 
       val newPosition = accumulated + currentFilePosition
       _totalPosition.value = newPosition

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
@@ -7,13 +7,11 @@ import android.os.Looper
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.google.common.util.concurrent.FutureCallback
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.MoreExecutors
-import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -51,7 +49,6 @@ class MediaRepository
     private val mediaChannel: LissenMediaProvider,
     private val eventBus: PlaybackEventBus,
     private val defaultTimerActivator: DefaultTimerActivator,
-    private val exoPlayer: Lazy<ExoPlayer>,
   ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private lateinit var mediaController: MediaController
@@ -444,13 +441,19 @@ class MediaRepository
     }
 
     private fun updateProgress(detailedItem: DetailedItem) {
-      val player = exoPlayer.get()
-      val currentIndex = player.currentMediaItemIndex
+      val currentIndex = mediaController.currentMediaItemIndex
       val chapters = detailedItem.chapters
       val accumulated = chapters.take(currentIndex.coerceIn(0, chapters.size)).sumOf { it.duration }
-      val currentFilePosition = player.currentPosition / 1000.0
+      val currentFilePosition = mediaController.currentPosition / 1000.0
 
-      val newPosition = accumulated + currentFilePosition
+      // In book scope the session player already reports book-scoped positions, so the
+      // accumulated chapter offsets would double-count.
+      val newPosition =
+        if (BookTimeScope.isBookTimeEnabled) {
+          currentFilePosition
+        } else {
+          accumulated + currentFilePosition
+        }
       _totalPosition.value = newPosition
       updateCurrentTrackData()
     }

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
@@ -447,9 +447,11 @@ class MediaRepository
       val currentFilePosition = mediaController.currentPosition / 1000.0
 
       // In book scope the session player already reports book-scoped positions, so the
-      // accumulated chapter offsets would double-count.
+      // accumulated chapter offsets would double-count. The snapshot book must match the
+      // playing book, exactly like the player's own scope check, so both fail closed to
+      // chapter scope together.
       val newPosition =
-        if (BookTimeScope.isBookTimeEnabled) {
+        if (BookTimeScope.book?.id == detailedItem.id) {
           currentFilePosition
         } else {
           accumulated + currentFilePosition

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaRepository.kt
@@ -7,6 +7,7 @@ import android.os.Looper
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.google.common.util.concurrent.FutureCallback
@@ -49,6 +50,7 @@ class MediaRepository
     private val mediaChannel: LissenMediaProvider,
     private val eventBus: PlaybackEventBus,
     private val defaultTimerActivator: DefaultTimerActivator,
+    private val exoPlayer: ExoPlayer,
   ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private lateinit var mediaController: MediaController
@@ -441,10 +443,10 @@ class MediaRepository
     }
 
     private fun updateProgress(detailedItem: DetailedItem) {
-      val currentIndex = mediaController.currentMediaItemIndex
+      val currentIndex = exoPlayer.currentMediaItemIndex
       val chapters = detailedItem.chapters
       val accumulated = chapters.take(currentIndex.coerceIn(0, chapters.size)).sumOf { it.duration }
-      val currentFilePosition = mediaController.currentPosition / 1000.0
+      val currentFilePosition = exoPlayer.currentPosition / 1000.0
 
       val newPosition = accumulated + currentFilePosition
       _totalPosition.value = newPosition

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactory.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactory.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.core.os.BundleCompat
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.ClippingMediaSource
 import androidx.media3.exoplayer.source.ConcatenatingMediaSource2
@@ -23,8 +24,10 @@ data class FileClip(
 
 @UnstableApi
 class LissenMediaSourceFactory(
-  private val mediaSourceFactory: DefaultMediaSourceFactory,
+  dataSourceFactory: DataSource.Factory,
 ) : MediaSource.Factory {
+  private val mediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory)
+
   data class MediaId(
     val bookId: String,
     val chapterId: Int,

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactory.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactory.kt
@@ -3,7 +3,6 @@ package org.grakovne.lissen.playback.service
 import android.os.Parcelable
 import androidx.core.os.BundleCompat
 import androidx.media3.common.MediaItem
-import androidx.media3.common.MediaMetadata
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.ClippingMediaSource
@@ -59,25 +58,33 @@ class LissenMediaSourceFactory(
 
   override fun getSupportedTypes(): IntArray = mediaSourceFactory.supportedTypes
 
+  /**
+   * The player reports the MediaItem of the MediaSource we return here, not the one it was given:
+   * both getCurrentMediaItem() and getMediaItemAt() read Timeline.Window.mediaItem, and that comes
+   * from the created source. So every source we build must carry the chapter item's identity
+   * (mediaId, requestMetadata with FILE_SEGMENTS, mediaMetadata with CHAPTER_START_MS) or it becomes
+   * invisible to PlaybackNavigationService and PlaybackSynchronizationService. Do not drop it.
+   */
   override fun createMediaSource(mediaItem: MediaItem): MediaSource {
     fun FileClip.toMediaSource(
       bookId: String,
-      metadata: MediaMetadata? = null,
-    ): MediaSource =
-      mediaSourceFactory
-        .createMediaSource(
-          MediaItem
-            .Builder()
-            .setUri(toLissenUri(bookId, fileId))
-            .apply { metadata?.let { setMediaMetadata(it) } }
-            .build(),
-        ).let {
+      template: MediaItem? = null,
+    ): MediaSource {
+      val innerItem =
+        (template?.buildUpon() ?: MediaItem.Builder())
+          .setUri(toLissenUri(bookId, fileId))
+          .build()
+
+      return mediaSourceFactory
+        .createMediaSource(innerItem)
+        .let {
           ClippingMediaSource
             .Builder(it)
             .setStartPositionUs((clipStart * 1_000_000).toLong())
             .setEndPositionUs((clipEnd * 1_000_000).toLong())
             .build()
         }
+    }
 
     return MediaId.fromString(mediaItem.mediaId)?.let { (bookId, chapterId) ->
       mediaItem.requestMetadata.extras?.let { extras ->
@@ -88,7 +95,7 @@ class LissenMediaSourceFactory(
             }
 
             1 -> {
-              segments.first().toMediaSource(bookId, mediaItem.mediaMetadata)
+              segments.first().toMediaSource(bookId, mediaItem)
             }
 
             else -> {
@@ -98,12 +105,8 @@ class LissenMediaSourceFactory(
                   segments.forEach {
                     add(it.toMediaSource(bookId), ((it.clipEnd - it.clipStart) * 1000).toLong())
                   }
-                }.setMediaItem(
-                  MediaItem
-                    .Builder()
-                    .setMediaMetadata(mediaItem.mediaMetadata)
-                    .build(),
-                ).build()
+                }.setMediaItem(mediaItem)
+                .build()
             }
           }
         }

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackNavigationService.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackNavigationService.kt
@@ -7,7 +7,6 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import org.grakovne.lissen.common.RunningComponent
 import org.grakovne.lissen.content.LissenMediaProvider
-import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -36,6 +35,12 @@ class PlaybackNavigationService
             }
           }
 
+          /**
+           * Skips chapters whose files are missing, which happens in offline mode when a book is
+           * only partly downloaded. Known limitation: this only covers transitions between items,
+           * so an unavailable first chapter is not skipped and still fails on load. Setting the
+           * playlist raises onTimelineChanged, not a discontinuity, so we never see it here.
+           */
           override fun onPositionDiscontinuity(
             oldPosition: Player.PositionInfo,
             newPosition: Player.PositionInfo,
@@ -43,15 +48,6 @@ class PlaybackNavigationService
           ) {
             val previousIndex = oldPosition.mediaItemIndex
             val currentIndex = newPosition.mediaItemIndex
-            val currentItem =
-              exoPlayer
-                .currentMediaItem
-                ?.localConfiguration
-                ?.tag as? DetailedItem
-
-            if (null == currentItem) {
-              return
-            }
 
             if (isTrackAvailable(exoPlayer.currentMediaItemIndex)) {
               return

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackService.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackService.kt
@@ -133,7 +133,7 @@ class PlaybackService : MediaLibraryService() {
             return@async
           }
 
-          BookTimeScope.update(sharedPreferences, libraryPreferences)
+          BookTimeScope.update(book, sharedPreferences, libraryPreferences)
           val itemsWithPosition = bookToChapterMediaItems(book)
 
           withContext(Dispatchers.Main) {

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackService.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackService.kt
@@ -260,8 +260,7 @@ class PlaybackService : MediaLibraryService() {
                 .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK_CHAPTER)
                 .setExtras(Bundle().apply { putLong(CHAPTER_START_MS, (chapter.start * 1000).toLong()) })
                 .build(),
-            ).setTag(book)
-            .build()
+            ).build()
         }
       return MediaItemsWithStartPosition(chapterMediaItems, chapterIndex, (chapterOffset * 1000).toLong())
     }

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackService.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackService.kt
@@ -24,7 +24,9 @@ import org.grakovne.lissen.domain.BookFile
 import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.PlayingChapter
 import org.grakovne.lissen.domain.TimerOption
+import org.grakovne.lissen.persistence.preferences.LibraryPreferences
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
+import org.grakovne.lissen.playback.BookTimeScope
 import org.grakovne.lissen.playback.MediaLibrarySessionProvider
 import org.grakovne.lissen.playback.PlaybackCommand
 import org.grakovne.lissen.playback.PlaybackEvent
@@ -45,6 +47,9 @@ class PlaybackService : MediaLibraryService() {
 
   @Inject
   lateinit var sharedPreferences: PlaybackPreferences
+
+  @Inject
+  lateinit var libraryPreferences: LibraryPreferences
 
   @Inject
   lateinit var playbackTimer: PlaybackTimer
@@ -128,6 +133,7 @@ class PlaybackService : MediaLibraryService() {
             return@async
           }
 
+          BookTimeScope.update(sharedPreferences, libraryPreferences)
           val itemsWithPosition = bookToChapterMediaItems(book)
 
           withContext(Dispatchers.Main) {

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/extensions/TimeExtensions.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/extensions/TimeExtensions.kt
@@ -65,3 +65,8 @@ fun Int.formatTime(): String {
     String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
   }
 }
+
+fun speedCompensatedSeconds(
+  seconds: Double,
+  playbackSpeed: Float,
+): Double = if (playbackSpeed > 0f) seconds / playbackSpeed else seconds

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/extensions/TimeExtensions.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/extensions/TimeExtensions.kt
@@ -65,8 +65,3 @@ fun Int.formatTime(): String {
     String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
   }
 }
-
-fun speedCompensatedSeconds(
-  seconds: Double,
-  playbackSpeed: Float,
-): Double = if (playbackSpeed > 0f) seconds / playbackSpeed else seconds

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/MediaDetailComposable.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/MediaDetailComposable.kt
@@ -45,6 +45,7 @@ import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.LibraryType
 import org.grakovne.lissen.ui.components.LissenModalBottomSheet
 import org.grakovne.lissen.ui.extensions.formatTime
+import org.grakovne.lissen.ui.extensions.speedCompensatedSeconds
 import org.grakovne.lissen.ui.navigation.AppNavigationService
 import org.grakovne.lissen.ui.screens.player.InfoRow
 import org.grakovne.lissen.viewmodel.PlayerViewModel
@@ -60,6 +61,7 @@ fun MediaDetailComposable(
   navController: AppNavigationService,
 ) {
   val totalPosition by playingViewModel.totalPosition.collectAsState()
+  val playbackSpeed by playingViewModel.playbackSpeed.collectAsState()
   val totalDuration = playingBook?.chapters?.sumOf { it.duration }
   val preferredLibrary by settingsViewModel.preferredLibrary.collectAsState()
 
@@ -172,7 +174,7 @@ fun MediaDetailComposable(
             InfoRow(
               icon = Icons.Filled.HourglassEmpty,
               label = stringResource(R.string.playing_item_details_time_remaining),
-              textValue = (it - totalPosition).toInt().formatTime(),
+              textValue = speedCompensatedSeconds(maxOf(0.0, it - totalPosition), playbackSpeed).toInt().formatTime(),
             )
           }
         }

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/MediaDetailComposable.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/MediaDetailComposable.kt
@@ -45,7 +45,6 @@ import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.LibraryType
 import org.grakovne.lissen.ui.components.LissenModalBottomSheet
 import org.grakovne.lissen.ui.extensions.formatTime
-import org.grakovne.lissen.ui.extensions.speedCompensatedSeconds
 import org.grakovne.lissen.ui.navigation.AppNavigationService
 import org.grakovne.lissen.ui.screens.player.InfoRow
 import org.grakovne.lissen.viewmodel.PlayerViewModel
@@ -61,7 +60,6 @@ fun MediaDetailComposable(
   navController: AppNavigationService,
 ) {
   val totalPosition by playingViewModel.totalPosition.collectAsState()
-  val playbackSpeed by playingViewModel.playbackSpeed.collectAsState()
   val totalDuration = playingBook?.chapters?.sumOf { it.duration }
   val preferredLibrary by settingsViewModel.preferredLibrary.collectAsState()
 
@@ -174,7 +172,7 @@ fun MediaDetailComposable(
             InfoRow(
               icon = Icons.Filled.HourglassEmpty,
               label = stringResource(R.string.playing_item_details_time_remaining),
-              textValue = speedCompensatedSeconds(maxOf(0.0, it - totalPosition), playbackSpeed).toInt().formatTime(),
+              textValue = maxOf(0.0, it - totalPosition).toInt().formatTime(),
             )
           }
         }

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/TrackControlComposable.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/TrackControlComposable.kt
@@ -44,7 +44,6 @@ import org.grakovne.lissen.R
 import org.grakovne.lissen.common.withHaptic
 import org.grakovne.lissen.domain.LibraryType
 import org.grakovne.lissen.ui.extensions.formatTime
-import org.grakovne.lissen.ui.extensions.speedCompensatedSeconds
 import org.grakovne.lissen.ui.extensions.spokenDuration
 import org.grakovne.lissen.ui.screens.player.composable.common.provideForwardIcon
 import org.grakovne.lissen.ui.screens.player.composable.common.provideReplayIcon
@@ -61,10 +60,10 @@ fun TrackControlComposable(
   val currentTrackIndex by viewModel.currentChapterIndex.collectAsState()
   val currentTrackPosition by viewModel.currentChapterPosition.collectAsState()
   val currentTrackDuration by viewModel.currentChapterDuration.collectAsState()
-  val playbackSpeed by viewModel.playbackSpeed.collectAsState()
+  val totalPosition by viewModel.totalPosition.collectAsState()
 
   val seekTime by settingsViewModel.seekTime.collectAsState()
-  val showBookTimeRemaining by settingsViewModel.showBookTimeRemaining.collectAsState()
+  val showBookTime by settingsViewModel.showBookTime.collectAsState()
   val preferredLibrary by settingsViewModel.preferredLibrary.collectAsState()
 
   val book by viewModel.book.collectAsState()
@@ -75,21 +74,35 @@ fun TrackControlComposable(
   var sliderPosition by remember { mutableDoubleStateOf(0.0) }
   var isDragging by remember { mutableStateOf(false) }
 
-  LaunchedEffect(currentTrackPosition, currentTrackIndex, currentTrackDuration) {
+  val bookDuration = chapters.sumOf { it.duration }
+  val bookScoped =
+    showBookTime && preferredLibrary?.type == LibraryType.LIBRARY && currentTrackIndex in chapters.indices
+
+  LaunchedEffect(currentTrackPosition, currentTrackIndex, currentTrackDuration, bookScoped, bookDuration) {
     if (!isDragging) {
-      sliderPosition = currentTrackPosition
+      sliderPosition =
+        if (bookScoped) {
+          chapters
+            .getOrNull(currentTrackIndex)
+            ?.let { it.start + currentTrackPosition }
+            ?: currentTrackPosition
+        } else {
+          currentTrackPosition
+        }
     }
   }
 
+  val displayPosition =
+    when {
+      bookScoped && isDragging -> sliderPosition
+      bookScoped -> totalPosition
+      else -> sliderPosition
+    }
+  val displayDuration = if (bookScoped) bookDuration else currentTrackDuration
+
   val remainingSeconds =
-    if (showBookTimeRemaining && preferredLibrary?.type == LibraryType.LIBRARY) {
-      chapters
-        .getOrNull(currentTrackIndex)
-        ?.let { chapter ->
-          val absolutePosition = chapter.start + sliderPosition
-          maxOf(0.0, chapters.sumOf { it.duration } - absolutePosition)
-        }
-        ?: maxOf(0.0, currentTrackDuration - sliderPosition)
+    if (bookScoped) {
+      maxOf(0.0, bookDuration - sliderPosition)
     } else {
       maxOf(0.0, currentTrackDuration - sliderPosition)
     }
@@ -105,8 +118,8 @@ fun TrackControlComposable(
     val spokenPosition =
       stringResource(
         R.string.a11y_position_of,
-        spokenDuration(sliderPosition.toInt()),
-        spokenDuration(currentTrackDuration.toInt()),
+        spokenDuration(displayPosition.toInt()),
+        spokenDuration(displayDuration.toInt()),
       )
 
     Column(
@@ -120,9 +133,18 @@ fun TrackControlComposable(
         },
         onValueChangeFinished = {
           isDragging = false
-          viewModel.seekTo(sliderPosition)
+          if (bookScoped) {
+            viewModel.setTotalPosition(sliderPosition)
+          } else {
+            viewModel.seekTo(sliderPosition)
+          }
         },
-        valueRange = 0f..currentTrackDuration.toFloat(),
+        valueRange =
+          if (bookScoped) {
+            0f..bookDuration.toFloat()
+          } else {
+            0f..currentTrackDuration.toFloat()
+          },
         colors =
           SliderDefaults.colors(
             thumbColor = colorScheme.primary,
@@ -151,16 +173,13 @@ fun TrackControlComposable(
           horizontalArrangement = Arrangement.SpaceBetween,
         ) {
           Text(
-            text = sliderPosition.toInt().formatTime(true),
+            text = displayPosition.toInt().formatTime(true),
             style = typography.bodySmall,
             color = colorScheme.onBackground.copy(alpha = 0.6f),
             modifier = Modifier.clearAndSetSemantics {},
           )
           Text(
-            text =
-              speedCompensatedSeconds(remainingSeconds, playbackSpeed)
-                .toInt()
-                .formatTime(true),
+            text = remainingSeconds.toInt().formatTime(true),
             style = typography.bodySmall,
             color = colorScheme.onBackground.copy(alpha = 0.6f),
             modifier = Modifier.clearAndSetSemantics {},

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/TrackControlComposable.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/TrackControlComposable.kt
@@ -42,7 +42,9 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import org.grakovne.lissen.R
 import org.grakovne.lissen.common.withHaptic
+import org.grakovne.lissen.domain.LibraryType
 import org.grakovne.lissen.ui.extensions.formatTime
+import org.grakovne.lissen.ui.extensions.speedCompensatedSeconds
 import org.grakovne.lissen.ui.extensions.spokenDuration
 import org.grakovne.lissen.ui.screens.player.composable.common.provideForwardIcon
 import org.grakovne.lissen.ui.screens.player.composable.common.provideReplayIcon
@@ -59,8 +61,11 @@ fun TrackControlComposable(
   val currentTrackIndex by viewModel.currentChapterIndex.collectAsState()
   val currentTrackPosition by viewModel.currentChapterPosition.collectAsState()
   val currentTrackDuration by viewModel.currentChapterDuration.collectAsState()
+  val playbackSpeed by viewModel.playbackSpeed.collectAsState()
 
   val seekTime by settingsViewModel.seekTime.collectAsState()
+  val showBookTimeRemaining by settingsViewModel.showBookTimeRemaining.collectAsState()
+  val preferredLibrary by settingsViewModel.preferredLibrary.collectAsState()
 
   val book by viewModel.book.collectAsState()
   val chapters = book?.chapters ?: emptyList()
@@ -75,6 +80,19 @@ fun TrackControlComposable(
       sliderPosition = currentTrackPosition
     }
   }
+
+  val remainingSeconds =
+    if (showBookTimeRemaining && preferredLibrary?.type == LibraryType.LIBRARY) {
+      chapters
+        .getOrNull(currentTrackIndex)
+        ?.let { chapter ->
+          val absolutePosition = chapter.start + sliderPosition
+          maxOf(0.0, chapters.sumOf { it.duration } - absolutePosition)
+        }
+        ?: maxOf(0.0, currentTrackDuration - sliderPosition)
+    } else {
+      maxOf(0.0, currentTrackDuration - sliderPosition)
+    }
 
   Column(
     modifier =
@@ -140,7 +158,7 @@ fun TrackControlComposable(
           )
           Text(
             text =
-              maxOf(0.0, currentTrackDuration - sliderPosition)
+              speedCompensatedSeconds(remainingSeconds, playbackSpeed)
                 .toInt()
                 .formatTime(true),
             style = typography.bodySmall,

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/settings/advanced/PlaybackPreferencesScreen.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/settings/advanced/PlaybackPreferencesScreen.kt
@@ -51,6 +51,7 @@ fun PlaybackPreferencesScreen(
   val viewModel: SettingsViewModel = hiltViewModel()
   val softwareCodecsEnabled by viewModel.softwareCodecsEnabled.collectAsState()
   val softwareCodecsEnabledOnStart = viewModel.softwareCodecsEnabledOnStart
+  val showBookTimeRemaining by viewModel.showBookTimeRemaining.collectAsState()
   val context = LocalContext.current
 
   Scaffold(
@@ -92,6 +93,12 @@ fun PlaybackPreferencesScreen(
         )
 
         DefaultTimerSettingsComposable(viewModel)
+
+        SettingsToggleItem(
+          title = stringResource(R.string.settings_screen_show_book_time_remaining_title),
+          description = stringResource(R.string.settings_screen_show_book_time_remaining_description),
+          initialState = showBookTimeRemaining,
+        ) { viewModel.preferShowBookTimeRemaining(it) }
 
         SettingsToggleItem(
           title = stringResource(R.string.settings_screen_software_codecs_enabled_title),

--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/settings/advanced/PlaybackPreferencesScreen.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/settings/advanced/PlaybackPreferencesScreen.kt
@@ -51,7 +51,7 @@ fun PlaybackPreferencesScreen(
   val viewModel: SettingsViewModel = hiltViewModel()
   val softwareCodecsEnabled by viewModel.softwareCodecsEnabled.collectAsState()
   val softwareCodecsEnabledOnStart = viewModel.softwareCodecsEnabledOnStart
-  val showBookTimeRemaining by viewModel.showBookTimeRemaining.collectAsState()
+  val showBookTime by viewModel.showBookTime.collectAsState()
   val context = LocalContext.current
 
   Scaffold(
@@ -95,10 +95,10 @@ fun PlaybackPreferencesScreen(
         DefaultTimerSettingsComposable(viewModel)
 
         SettingsToggleItem(
-          title = stringResource(R.string.settings_screen_show_book_time_remaining_title),
-          description = stringResource(R.string.settings_screen_show_book_time_remaining_description),
-          initialState = showBookTimeRemaining,
-        ) { viewModel.preferShowBookTimeRemaining(it) }
+          title = stringResource(R.string.settings_screen_show_book_time_title),
+          description = stringResource(R.string.settings_screen_show_book_time_description),
+          initialState = showBookTime,
+        ) { viewModel.preferShowBookTime(it) }
 
         SettingsToggleItem(
           title = stringResource(R.string.settings_screen_software_codecs_enabled_title),

--- a/app/src/main/kotlin/org/grakovne/lissen/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/viewmodel/SettingsViewModel.kt
@@ -143,9 +143,9 @@ class SettingsViewModel
     val softwareCodecsEnabled: StateFlow<Boolean> = _softwareCodecsEnabled.asStateFlow()
     val softwareCodecsEnabledOnStart: Boolean = playback.getSoftwareCodecsEnabled()
 
-    private val _showBookTimeRemaining = MutableStateFlow(playback.getShowBookTimeRemaining())
+    private val _showBookTime = MutableStateFlow(playback.getShowBookTime())
 
-    val showBookTimeRemaining: StateFlow<Boolean> = _showBookTimeRemaining.asStateFlow()
+    val showBookTime: StateFlow<Boolean> = _showBookTime.asStateFlow()
 
     private val _audioFocusLossPolicy = MutableStateFlow(playback.getAudioFocusLossPolicy())
 
@@ -377,10 +377,10 @@ class SettingsViewModel
       playback.saveSoftwareCodecsEnabled(value)
     }
 
-    fun preferShowBookTimeRemaining(value: Boolean) {
-      Timber.d("User action: preferShowBookTimeRemaining $value")
-      _showBookTimeRemaining.value = value
-      playback.saveShowBookTimeRemaining(value)
+    fun preferShowBookTime(value: Boolean) {
+      Timber.d("User action: preferShowBookTime $value")
+      _showBookTime.value = value
+      playback.saveShowBookTime(value)
     }
 
     fun preferActivityLoggingEnabled(value: Boolean) {

--- a/app/src/main/kotlin/org/grakovne/lissen/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/viewmodel/SettingsViewModel.kt
@@ -143,6 +143,10 @@ class SettingsViewModel
     val softwareCodecsEnabled: StateFlow<Boolean> = _softwareCodecsEnabled.asStateFlow()
     val softwareCodecsEnabledOnStart: Boolean = playback.getSoftwareCodecsEnabled()
 
+    private val _showBookTimeRemaining = MutableStateFlow(playback.getShowBookTimeRemaining())
+
+    val showBookTimeRemaining: StateFlow<Boolean> = _showBookTimeRemaining.asStateFlow()
+
     private val _audioFocusLossPolicy = MutableStateFlow(playback.getAudioFocusLossPolicy())
 
     val audioFocusLossPolicy: StateFlow<AudioFocusLossPolicy> = _audioFocusLossPolicy.asStateFlow()
@@ -371,6 +375,12 @@ class SettingsViewModel
       Timber.d("User action: preferSoftwareCodecsEnabled $value")
       _softwareCodecsEnabled.value = value
       playback.saveSoftwareCodecsEnabled(value)
+    }
+
+    fun preferShowBookTimeRemaining(value: Boolean) {
+      Timber.d("User action: preferShowBookTimeRemaining $value")
+      _showBookTimeRemaining.value = value
+      playback.saveShowBookTimeRemaining(value)
     }
 
     fun preferActivityLoggingEnabled(value: Boolean) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,8 +196,8 @@
     <string name="settings_screen_crash_report_description">Send reports if the app crashes</string>
     <string name="settings_screen_software_codecs_enabled_title">Force software decoding</string>
     <string name="settings_screen_software_codecs_enabled_description">Use software codecs for audio playback</string>
-    <string name="settings_screen_show_book_time_remaining_title">Show book time remaining</string>
-    <string name="settings_screen_show_book_time_remaining_description">Show remaining time for the whole book instead of the current chapter</string>
+    <string name="settings_screen_show_book_time_title">Show book time instead of chapter time</string>
+    <string name="settings_screen_show_book_time_description">The progress bar and all times cover the whole book rather than the current chapter</string>
     <string name="settings_screen_audio_focus_loss_policy_title">Playback on notification</string>
     <string name="settings_screen_audio_focus_loss_policy_option_pause">Pause</string>
     <string name="settings_screen_audio_focus_loss_policy_option_lower_volume">Lower volume</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,6 +196,8 @@
     <string name="settings_screen_crash_report_description">Send reports if the app crashes</string>
     <string name="settings_screen_software_codecs_enabled_title">Force software decoding</string>
     <string name="settings_screen_software_codecs_enabled_description">Use software codecs for audio playback</string>
+    <string name="settings_screen_show_book_time_remaining_title">Show book time remaining</string>
+    <string name="settings_screen_show_book_time_remaining_description">Show remaining time for the whole book instead of the current chapter</string>
     <string name="settings_screen_audio_focus_loss_policy_title">Playback on notification</string>
     <string name="settings_screen_audio_focus_loss_policy_option_pause">Pause</string>
     <string name="settings_screen_audio_focus_loss_policy_option_lower_volume">Lower volume</string>

--- a/app/src/test/kotlin/org/grakovne/lissen/persistence/preferences/PlaybackPreferencesShowBookTimeTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/persistence/preferences/PlaybackPreferencesShowBookTimeTest.kt
@@ -1,0 +1,54 @@
+package org.grakovne.lissen.persistence.preferences
+
+import android.content.Context
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PlaybackPreferencesShowBookTimeTest {
+  private val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+  private val sharedPreferences = mockk<SharedPreferences>(relaxed = true)
+  private val context = mockk<Context>(relaxed = true)
+  private lateinit var preferences: PlaybackPreferences
+
+  @BeforeEach
+  fun setup() {
+    every { context.getSharedPreferences(any(), any()) } returns sharedPreferences
+    every { sharedPreferences.edit() } returns editor
+    every { editor.remove(any()) } returns editor
+    every { editor.commit() } returns true
+    preferences = PlaybackPreferences(SecurePreferenceStore(context), LibraryPreferences(SecurePreferenceStore(context)))
+  }
+
+  @Nested
+  inner class GetShowBookTime {
+    @Test
+    fun `returns false when no preference stored`() {
+      every { sharedPreferences.getBoolean("show_book_time_remaining", false) } returns false
+
+      assertEquals(false, preferences.getShowBookTime())
+    }
+
+    @Test
+    fun `returns stored value`() {
+      every { sharedPreferences.getBoolean("show_book_time_remaining", false) } returns true
+
+      assertEquals(true, preferences.getShowBookTime())
+    }
+  }
+
+  @Nested
+  inner class SaveShowBookTime {
+    @Test
+    fun `stores the value under the legacy key so existing values keep working`() {
+      preferences.saveShowBookTime(true)
+
+      verify { editor.putBoolean("show_book_time_remaining", true) }
+    }
+  }
+}

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayerTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayerTest.kt
@@ -32,20 +32,15 @@ class BookTimeForwardingPlayerTest {
 
   @BeforeEach
   fun resetBookTimeScope() {
-    BookTimeScope.update(playbackPreferences, libraryPreferences)
+    BookTimeScope.update(book, playbackPreferences, libraryPreferences)
   }
 
-  private fun createWrapper() =
-    BookTimeForwardingPlayer(
-      player = delegate,
-      playbackPreferences = playbackPreferences,
-    )
+  private fun createWrapper() = BookTimeForwardingPlayer(player = delegate)
 
-  private fun enableTranslation() {
+  private fun enableTranslation(book: DetailedItem = this.book) {
     every { playbackPreferences.getShowBookTime() } returns true
     every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
-    every { playbackPreferences.getPlayingItem() } returns book
-    BookTimeScope.update(playbackPreferences, libraryPreferences)
+    BookTimeScope.update(book, playbackPreferences, libraryPreferences)
   }
 
   private fun setCurrentMediaItem(
@@ -159,13 +154,21 @@ class BookTimeForwardingPlayerTest {
     }
 
     @Test
-    fun `position translation uses the media item offset instead of the stored book`() {
-      enableTranslation()
-      every { playbackPreferences.getPlayingItem() } returns createBook(50.0, 50.0).copy(id = "another-book")
-      setCurrentMediaItem(mediaId = "chapter:book:0", chapterStartMs = 100_000L)
+    fun `position translation uses the media item offset instead of the snapshot book chapter starts`() {
+      enableTranslation(book = createBook(50.0, 50.0))
+      setCurrentMediaItem(chapterStartMs = 100_000L)
       every { delegate.currentPosition } returns 50_000L
 
       assertEquals(150_000L, createWrapper().getCurrentPosition())
+    }
+
+    @Test
+    fun `position with media id not matching the snapshot book passes through`() {
+      enableTranslation()
+      setCurrentMediaItem(mediaId = "chapter:another-book:0", chapterStartMs = 100_000L)
+      every { delegate.currentPosition } returns 50_000L
+
+      assertEquals(50_000L, createWrapper().getCurrentPosition())
     }
 
     @Test
@@ -233,7 +236,7 @@ class BookTimeForwardingPlayerTest {
     }
 
     @Test
-    fun `duration with mismatched stored book passes through`() {
+    fun `duration with media id not matching the snapshot book passes through`() {
       enableTranslation()
       setCurrentMediaItem(mediaId = "chapter:another-book:0")
       every { delegate.duration } returns 100_000L
@@ -293,7 +296,7 @@ class BookTimeForwardingPlayerTest {
     }
 
     @Test
-    fun `single position seek with mismatched stored book forwards untouched`() {
+    fun `single position seek with media id not matching the snapshot book forwards untouched`() {
       enableTranslation()
       setCurrentMediaItem(mediaId = "chapter:another-book:0")
 
@@ -318,7 +321,7 @@ class BookTimeForwardingPlayerTest {
     @Test
     fun `setting off reports chapter values`() {
       every { playbackPreferences.getShowBookTime() } returns false
-      BookTimeScope.update(playbackPreferences, libraryPreferences)
+      BookTimeScope.update(book, playbackPreferences, libraryPreferences)
       every { delegate.currentPosition } returns 50_000L
       every { delegate.duration } returns 100_000L
 
@@ -331,7 +334,7 @@ class BookTimeForwardingPlayerTest {
     @Test
     fun `setting off forwards single position seek untouched`() {
       every { playbackPreferences.getShowBookTime() } returns false
-      BookTimeScope.update(playbackPreferences, libraryPreferences)
+      BookTimeScope.update(book, playbackPreferences, libraryPreferences)
 
       createWrapper().seekTo(150_000L)
 
@@ -342,19 +345,7 @@ class BookTimeForwardingPlayerTest {
     fun `podcast library reports chapter values`() {
       every { playbackPreferences.getShowBookTime() } returns true
       every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Podcasts", type = LibraryType.PODCAST)
-      every { playbackPreferences.getPlayingItem() } returns book
-      BookTimeScope.update(playbackPreferences, libraryPreferences)
-      every { delegate.currentPosition } returns 50_000L
-
-      assertEquals(50_000L, createWrapper().getCurrentPosition())
-    }
-
-    @Test
-    fun `no playing item reports chapter values`() {
-      every { playbackPreferences.getShowBookTime() } returns true
-      every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
-      every { playbackPreferences.getPlayingItem() } returns null
-      BookTimeScope.update(playbackPreferences, libraryPreferences)
+      BookTimeScope.update(book, playbackPreferences, libraryPreferences)
       every { delegate.currentPosition } returns 50_000L
 
       assertEquals(50_000L, createWrapper().getCurrentPosition())
@@ -364,8 +355,7 @@ class BookTimeForwardingPlayerTest {
     fun `book without chapters reports chapter values`() {
       every { playbackPreferences.getShowBookTime() } returns true
       every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
-      every { playbackPreferences.getPlayingItem() } returns createBook()
-      BookTimeScope.update(playbackPreferences, libraryPreferences)
+      BookTimeScope.update(createBook(), playbackPreferences, libraryPreferences)
       every { delegate.currentPosition } returns 50_000L
       every { delegate.duration } returns 100_000L
 
@@ -379,12 +369,11 @@ class BookTimeForwardingPlayerTest {
   @Test
   fun `translation uses the scope snapshot taken at playlist build instead of the current preference`() {
     every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
-    every { playbackPreferences.getPlayingItem() } returns book
     setCurrentMediaItem(chapterStartMs = 100_000L)
     every { delegate.currentPosition } returns 50_000L
 
     every { playbackPreferences.getShowBookTime() } returns true
-    BookTimeScope.update(playbackPreferences, libraryPreferences)
+    BookTimeScope.update(book, playbackPreferences, libraryPreferences)
     val wrapper = createWrapper()
 
     every { playbackPreferences.getShowBookTime() } returns false

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayerTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayerTest.kt
@@ -18,6 +18,7 @@ import org.grakovne.lissen.persistence.preferences.LibraryPreferences
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
 import org.grakovne.lissen.playback.service.PlaybackService
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -29,17 +30,22 @@ class BookTimeForwardingPlayerTest {
 
   private val book = createBook(100.0, 100.0)
 
+  @BeforeEach
+  fun resetBookTimeScope() {
+    BookTimeScope.update(playbackPreferences, libraryPreferences)
+  }
+
   private fun createWrapper() =
     BookTimeForwardingPlayer(
       player = delegate,
       playbackPreferences = playbackPreferences,
-      libraryPreferences = libraryPreferences,
     )
 
   private fun enableTranslation() {
     every { playbackPreferences.getShowBookTime() } returns true
     every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
     every { playbackPreferences.getPlayingItem() } returns book
+    BookTimeScope.update(playbackPreferences, libraryPreferences)
   }
 
   private fun setCurrentMediaItem(
@@ -312,6 +318,7 @@ class BookTimeForwardingPlayerTest {
     @Test
     fun `setting off reports chapter values`() {
       every { playbackPreferences.getShowBookTime() } returns false
+      BookTimeScope.update(playbackPreferences, libraryPreferences)
       every { delegate.currentPosition } returns 50_000L
       every { delegate.duration } returns 100_000L
 
@@ -324,6 +331,7 @@ class BookTimeForwardingPlayerTest {
     @Test
     fun `setting off forwards single position seek untouched`() {
       every { playbackPreferences.getShowBookTime() } returns false
+      BookTimeScope.update(playbackPreferences, libraryPreferences)
 
       createWrapper().seekTo(150_000L)
 
@@ -335,6 +343,7 @@ class BookTimeForwardingPlayerTest {
       every { playbackPreferences.getShowBookTime() } returns true
       every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Podcasts", type = LibraryType.PODCAST)
       every { playbackPreferences.getPlayingItem() } returns book
+      BookTimeScope.update(playbackPreferences, libraryPreferences)
       every { delegate.currentPosition } returns 50_000L
 
       assertEquals(50_000L, createWrapper().getCurrentPosition())
@@ -345,6 +354,7 @@ class BookTimeForwardingPlayerTest {
       every { playbackPreferences.getShowBookTime() } returns true
       every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
       every { playbackPreferences.getPlayingItem() } returns null
+      BookTimeScope.update(playbackPreferences, libraryPreferences)
       every { delegate.currentPosition } returns 50_000L
 
       assertEquals(50_000L, createWrapper().getCurrentPosition())
@@ -355,6 +365,7 @@ class BookTimeForwardingPlayerTest {
       every { playbackPreferences.getShowBookTime() } returns true
       every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
       every { playbackPreferences.getPlayingItem() } returns createBook()
+      BookTimeScope.update(playbackPreferences, libraryPreferences)
       every { delegate.currentPosition } returns 50_000L
       every { delegate.duration } returns 100_000L
 
@@ -366,17 +377,17 @@ class BookTimeForwardingPlayerTest {
   }
 
   @Test
-  fun `translation reads the preference at call time instead of a snapshot`() {
+  fun `translation uses the scope snapshot taken at playlist build instead of the current preference`() {
     every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
     every { playbackPreferences.getPlayingItem() } returns book
     setCurrentMediaItem(chapterStartMs = 100_000L)
     every { delegate.currentPosition } returns 50_000L
-    val wrapper = createWrapper()
 
     every { playbackPreferences.getShowBookTime() } returns true
-    assertEquals(150_000L, wrapper.getCurrentPosition())
+    BookTimeScope.update(playbackPreferences, libraryPreferences)
+    val wrapper = createWrapper()
 
     every { playbackPreferences.getShowBookTime() } returns false
-    assertEquals(50_000L, wrapper.getCurrentPosition())
+    assertEquals(150_000L, wrapper.getCurrentPosition())
   }
 }

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayerTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayerTest.kt
@@ -1,0 +1,379 @@
+package org.grakovne.lissen.playback
+
+import android.os.Bundle
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.grakovne.lissen.domain.DetailedItem
+import org.grakovne.lissen.domain.Library
+import org.grakovne.lissen.domain.LibraryType
+import org.grakovne.lissen.domain.PlayingChapter
+import org.grakovne.lissen.persistence.preferences.LibraryPreferences
+import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
+import org.grakovne.lissen.playback.service.PlaybackService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class BookTimeForwardingPlayerTest {
+  private val delegate = mockk<Player>(relaxed = true)
+  private val playbackPreferences = mockk<PlaybackPreferences>(relaxed = true)
+  private val libraryPreferences = mockk<LibraryPreferences>(relaxed = true)
+
+  private val book = createBook(100.0, 100.0)
+
+  private fun createWrapper() =
+    BookTimeForwardingPlayer(
+      player = delegate,
+      playbackPreferences = playbackPreferences,
+      libraryPreferences = libraryPreferences,
+    )
+
+  private fun enableTranslation() {
+    every { playbackPreferences.getShowBookTime() } returns true
+    every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
+    every { playbackPreferences.getPlayingItem() } returns book
+  }
+
+  private fun setCurrentMediaItem(
+    mediaId: String = "chapter:book:0",
+    chapterStartMs: Long? = 100_000L,
+  ) {
+    val metadata =
+      MediaMetadata
+        .Builder()
+        .apply {
+          chapterStartMs?.let {
+            val extras = mockk<Bundle>()
+            every { extras.getLong(PlaybackService.CHAPTER_START_MS, -1) } returns it
+            setExtras(extras)
+          }
+        }.build()
+    val mediaItem =
+      MediaItem
+        .Builder()
+        .setMediaId(mediaId)
+        .setMediaMetadata(metadata)
+        .build()
+    every { delegate.currentMediaItem } returns mediaItem
+  }
+
+  private fun createBook(vararg chapterDurations: Number): DetailedItem {
+    val chapters =
+      buildList {
+        var start = 0.0
+        chapterDurations.forEachIndexed { index, duration ->
+          add(
+            PlayingChapter(
+              available = true,
+              podcastEpisodeState = null,
+              duration = duration.toDouble(),
+              start = start,
+              end = start + duration.toDouble(),
+              title = "$index",
+              id = "$index",
+            ),
+          )
+          start += duration.toDouble()
+        }
+      }
+
+    return DetailedItem(
+      id = "book",
+      title = "",
+      subtitle = "",
+      author = "",
+      narrator = "",
+      publisher = "",
+      series = listOf(),
+      year = "",
+      abstract = "",
+      files = listOf(),
+      chapters = chapters,
+      progress = null,
+      libraryId = "lib",
+      localProvided = false,
+      createdAt = 0,
+      updatedAt = 0,
+    )
+  }
+
+  @Nested
+  inner class PositionTranslation {
+    @Test
+    fun `current position becomes book position`() {
+      enableTranslation()
+      setCurrentMediaItem(chapterStartMs = 100_000L)
+      every { delegate.currentPosition } returns 50_000L
+
+      assertEquals(150_000L, createWrapper().getCurrentPosition())
+    }
+
+    @Test
+    fun `content position becomes book position`() {
+      enableTranslation()
+      setCurrentMediaItem(chapterStartMs = 100_000L)
+      every { delegate.contentPosition } returns 30_000L
+
+      assertEquals(130_000L, createWrapper().getContentPosition())
+    }
+
+    @Test
+    fun `buffered position becomes book position`() {
+      enableTranslation()
+      setCurrentMediaItem(chapterStartMs = 100_000L)
+      every { delegate.bufferedPosition } returns 70_000L
+
+      assertEquals(170_000L, createWrapper().getBufferedPosition())
+    }
+
+    @Test
+    fun `content buffered position becomes book position`() {
+      enableTranslation()
+      setCurrentMediaItem(chapterStartMs = 100_000L)
+      every { delegate.contentBufferedPosition } returns 70_000L
+
+      assertEquals(170_000L, createWrapper().getContentBufferedPosition())
+    }
+
+    @Test
+    fun `first chapter positions are translated with zero offset`() {
+      enableTranslation()
+      setCurrentMediaItem(chapterStartMs = 0L)
+      every { delegate.currentPosition } returns 25_000L
+
+      assertEquals(25_000L, createWrapper().getCurrentPosition())
+    }
+
+    @Test
+    fun `position translation uses the media item offset instead of the stored book`() {
+      enableTranslation()
+      every { playbackPreferences.getPlayingItem() } returns createBook(50.0, 50.0).copy(id = "another-book")
+      setCurrentMediaItem(mediaId = "chapter:book:0", chapterStartMs = 100_000L)
+      every { delegate.currentPosition } returns 50_000L
+
+      assertEquals(150_000L, createWrapper().getCurrentPosition())
+    }
+
+    @Test
+    fun `unknown buffered position passes through`() {
+      enableTranslation()
+      setCurrentMediaItem(chapterStartMs = 100_000L)
+      every { delegate.bufferedPosition } returns C.TIME_UNSET
+
+      assertEquals(C.TIME_UNSET, createWrapper().getBufferedPosition())
+    }
+
+    @Test
+    fun `position without chapter start extra passes through`() {
+      enableTranslation()
+      setCurrentMediaItem(chapterStartMs = null)
+      every { delegate.currentPosition } returns 50_000L
+
+      assertEquals(50_000L, createWrapper().getCurrentPosition())
+    }
+
+    @Test
+    fun `position with unset chapter start sentinel passes through`() {
+      enableTranslation()
+      setCurrentMediaItem(chapterStartMs = -1L)
+      every { delegate.currentPosition } returns 50_000L
+
+      assertEquals(50_000L, createWrapper().getCurrentPosition())
+    }
+  }
+
+  @Nested
+  inner class DurationTranslation {
+    @Test
+    fun `duration becomes total book duration`() {
+      enableTranslation()
+      setCurrentMediaItem()
+      every { delegate.duration } returns 100_000L
+
+      assertEquals(200_000L, createWrapper().getDuration())
+    }
+
+    @Test
+    fun `content duration becomes total book duration`() {
+      enableTranslation()
+      setCurrentMediaItem()
+      every { delegate.contentDuration } returns 100_000L
+
+      assertEquals(200_000L, createWrapper().getContentDuration())
+    }
+
+    @Test
+    fun `unset duration passes through`() {
+      enableTranslation()
+      every { delegate.duration } returns C.TIME_UNSET
+
+      assertEquals(C.TIME_UNSET, createWrapper().getDuration())
+    }
+
+    @Test
+    fun `unset content duration passes through`() {
+      enableTranslation()
+      every { delegate.contentDuration } returns C.TIME_UNSET
+
+      assertEquals(C.TIME_UNSET, createWrapper().getContentDuration())
+    }
+
+    @Test
+    fun `duration with mismatched stored book passes through`() {
+      enableTranslation()
+      setCurrentMediaItem(mediaId = "chapter:another-book:0")
+      every { delegate.duration } returns 100_000L
+
+      assertEquals(100_000L, createWrapper().getDuration())
+    }
+
+    @Test
+    fun `duration with unparseable media id passes through`() {
+      enableTranslation()
+      setCurrentMediaItem(mediaId = "not-a-chapter-media-id")
+      every { delegate.duration } returns 100_000L
+
+      assertEquals(100_000L, createWrapper().getDuration())
+    }
+  }
+
+  @Nested
+  inner class SeekTranslation {
+    @Test
+    fun `single position seek within first chapter maps to chapter index and offset`() {
+      enableTranslation()
+      setCurrentMediaItem()
+
+      createWrapper().seekTo(25_000L)
+
+      verify { delegate.seekTo(0, 25_000L) }
+    }
+
+    @Test
+    fun `single position seek across a chapter boundary maps to next chapter`() {
+      enableTranslation()
+      setCurrentMediaItem()
+
+      createWrapper().seekTo(150_000L)
+
+      verify { delegate.seekTo(1, 50_000L) }
+    }
+
+    @Test
+    fun `single position seek beyond the book end clamps to the last chapter start`() {
+      enableTranslation()
+      setCurrentMediaItem()
+
+      createWrapper().seekTo(999_000L)
+
+      verify { delegate.seekTo(1, 0L) }
+    }
+
+    @Test
+    fun `media item seek with a position forwards untouched`() {
+      enableTranslation()
+
+      createWrapper().seekTo(0, 5_000L)
+
+      verify { delegate.seekTo(0, 5_000L) }
+    }
+
+    @Test
+    fun `single position seek with mismatched stored book forwards untouched`() {
+      enableTranslation()
+      setCurrentMediaItem(mediaId = "chapter:another-book:0")
+
+      createWrapper().seekTo(150_000L)
+
+      verify { delegate.seekTo(150_000L) }
+    }
+
+    @Test
+    fun `single position seek with unparseable media id forwards untouched`() {
+      enableTranslation()
+      setCurrentMediaItem(mediaId = "not-a-chapter-media-id")
+
+      createWrapper().seekTo(150_000L)
+
+      verify { delegate.seekTo(150_000L) }
+    }
+  }
+
+  @Nested
+  inner class PassThrough {
+    @Test
+    fun `setting off reports chapter values`() {
+      every { playbackPreferences.getShowBookTime() } returns false
+      every { delegate.currentPosition } returns 50_000L
+      every { delegate.duration } returns 100_000L
+
+      val wrapper = createWrapper()
+
+      assertEquals(50_000L, wrapper.getCurrentPosition())
+      assertEquals(100_000L, wrapper.getDuration())
+    }
+
+    @Test
+    fun `setting off forwards single position seek untouched`() {
+      every { playbackPreferences.getShowBookTime() } returns false
+
+      createWrapper().seekTo(150_000L)
+
+      verify { delegate.seekTo(150_000L) }
+    }
+
+    @Test
+    fun `podcast library reports chapter values`() {
+      every { playbackPreferences.getShowBookTime() } returns true
+      every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Podcasts", type = LibraryType.PODCAST)
+      every { playbackPreferences.getPlayingItem() } returns book
+      every { delegate.currentPosition } returns 50_000L
+
+      assertEquals(50_000L, createWrapper().getCurrentPosition())
+    }
+
+    @Test
+    fun `no playing item reports chapter values`() {
+      every { playbackPreferences.getShowBookTime() } returns true
+      every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
+      every { playbackPreferences.getPlayingItem() } returns null
+      every { delegate.currentPosition } returns 50_000L
+
+      assertEquals(50_000L, createWrapper().getCurrentPosition())
+    }
+
+    @Test
+    fun `book without chapters reports chapter values`() {
+      every { playbackPreferences.getShowBookTime() } returns true
+      every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
+      every { playbackPreferences.getPlayingItem() } returns createBook()
+      every { delegate.currentPosition } returns 50_000L
+      every { delegate.duration } returns 100_000L
+
+      val wrapper = createWrapper()
+
+      assertEquals(50_000L, wrapper.getCurrentPosition())
+      assertEquals(100_000L, wrapper.getDuration())
+    }
+  }
+
+  @Test
+  fun `translation reads the preference at call time instead of a snapshot`() {
+    every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
+    every { playbackPreferences.getPlayingItem() } returns book
+    setCurrentMediaItem(chapterStartMs = 100_000L)
+    every { delegate.currentPosition } returns 50_000L
+    val wrapper = createWrapper()
+
+    every { playbackPreferences.getShowBookTime() } returns true
+    assertEquals(150_000L, wrapper.getCurrentPosition())
+
+    every { playbackPreferences.getShowBookTime() } returns false
+    assertEquals(50_000L, wrapper.getCurrentPosition())
+  }
+}

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayerTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayerTest.kt
@@ -1,10 +1,12 @@
 package org.grakovne.lissen.playback
 
 import android.os.Bundle
+import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -19,6 +21,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+@OptIn(UnstableApi::class)
 class BookTimeForwardingPlayerTest {
   private val delegate = mockk<Player>(relaxed = true)
   private val playbackPreferences = mockk<PlaybackPreferences>(relaxed = true)

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayerTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeForwardingPlayerTest.kt
@@ -172,6 +172,15 @@ class BookTimeForwardingPlayerTest {
     }
 
     @Test
+    fun `position with unparseable media id passes through`() {
+      enableTranslation()
+      setCurrentMediaItem(mediaId = "not-a-chapter-media-id", chapterStartMs = 100_000L)
+      every { delegate.currentPosition } returns 50_000L
+
+      assertEquals(50_000L, createWrapper().getCurrentPosition())
+    }
+
+    @Test
     fun `unknown buffered position passes through`() {
       enableTranslation()
       setCurrentMediaItem(chapterStartMs = 100_000L)
@@ -252,6 +261,15 @@ class BookTimeForwardingPlayerTest {
 
       assertEquals(100_000L, createWrapper().getDuration())
     }
+
+    @Test
+    fun `duration without chapter start extra passes through`() {
+      enableTranslation()
+      setCurrentMediaItem(chapterStartMs = null)
+      every { delegate.duration } returns 100_000L
+
+      assertEquals(100_000L, createWrapper().getDuration())
+    }
   }
 
   @Nested
@@ -277,13 +295,23 @@ class BookTimeForwardingPlayerTest {
     }
 
     @Test
-    fun `single position seek beyond the book end clamps to the last chapter start`() {
+    fun `single position seek at the book end seeks to the end of the last chapter`() {
+      enableTranslation()
+      setCurrentMediaItem()
+
+      createWrapper().seekTo(200_000L)
+
+      verify { delegate.seekTo(1, 100_000L) }
+    }
+
+    @Test
+    fun `single position seek beyond the book end seeks to the end of the last chapter`() {
       enableTranslation()
       setCurrentMediaItem()
 
       createWrapper().seekTo(999_000L)
 
-      verify { delegate.seekTo(1, 0L) }
+      verify { delegate.seekTo(1, 100_000L) }
     }
 
     @Test

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeScopeTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeScopeTest.kt
@@ -1,0 +1,66 @@
+package org.grakovne.lissen.playback
+
+import io.mockk.every
+import io.mockk.mockk
+import org.grakovne.lissen.domain.Library
+import org.grakovne.lissen.domain.LibraryType
+import org.grakovne.lissen.persistence.preferences.LibraryPreferences
+import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class BookTimeScopeTest {
+  private val playbackPreferences = mockk<PlaybackPreferences>(relaxed = true)
+  private val libraryPreferences = mockk<LibraryPreferences>(relaxed = true)
+
+  @BeforeEach
+  fun reset() {
+    BookTimeScope.update(playbackPreferences, libraryPreferences)
+  }
+
+  private fun setScopeEnabled() {
+    every { playbackPreferences.getShowBookTime() } returns true
+    every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
+  }
+
+  @Test
+  fun `enabled for a book library with the setting on`() {
+    setScopeEnabled()
+
+    BookTimeScope.update(playbackPreferences, libraryPreferences)
+
+    assertTrue(BookTimeScope.isBookTimeEnabled)
+  }
+
+  @Test
+  fun `disabled when the setting is off`() {
+    setScopeEnabled()
+    every { playbackPreferences.getShowBookTime() } returns false
+
+    BookTimeScope.update(playbackPreferences, libraryPreferences)
+
+    assertFalse(BookTimeScope.isBookTimeEnabled)
+  }
+
+  @Test
+  fun `disabled for a podcast library`() {
+    every { playbackPreferences.getShowBookTime() } returns true
+    every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Podcasts", type = LibraryType.PODCAST)
+
+    BookTimeScope.update(playbackPreferences, libraryPreferences)
+
+    assertFalse(BookTimeScope.isBookTimeEnabled)
+  }
+
+  @Test
+  fun `disabled when no library is preferred`() {
+    every { playbackPreferences.getShowBookTime() } returns true
+    every { libraryPreferences.getPreferredLibrary() } returns null
+
+    BookTimeScope.update(playbackPreferences, libraryPreferences)
+
+    assertFalse(BookTimeScope.isBookTimeEnabled)
+  }
+}

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeScopeTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/BookTimeScopeTest.kt
@@ -2,12 +2,14 @@ package org.grakovne.lissen.playback
 
 import io.mockk.every
 import io.mockk.mockk
+import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.Library
 import org.grakovne.lissen.domain.LibraryType
+import org.grakovne.lissen.domain.PlayingChapter
 import org.grakovne.lissen.persistence.preferences.LibraryPreferences
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -15,9 +17,11 @@ class BookTimeScopeTest {
   private val playbackPreferences = mockk<PlaybackPreferences>(relaxed = true)
   private val libraryPreferences = mockk<LibraryPreferences>(relaxed = true)
 
+  private val book = createBook(id = "book")
+
   @BeforeEach
   fun reset() {
-    BookTimeScope.update(playbackPreferences, libraryPreferences)
+    BookTimeScope.update(book, playbackPreferences, libraryPreferences)
   }
 
   private fun setScopeEnabled() {
@@ -26,41 +30,87 @@ class BookTimeScopeTest {
   }
 
   @Test
-  fun `enabled for a book library with the setting on`() {
+  fun `holds the prepared book for a book library with the setting on`() {
     setScopeEnabled()
 
-    BookTimeScope.update(playbackPreferences, libraryPreferences)
+    BookTimeScope.update(book, playbackPreferences, libraryPreferences)
 
-    assertTrue(BookTimeScope.isBookTimeEnabled)
+    assertEquals(book, BookTimeScope.book)
   }
 
   @Test
-  fun `disabled when the setting is off`() {
+  fun `empty when the setting is off`() {
     setScopeEnabled()
     every { playbackPreferences.getShowBookTime() } returns false
 
-    BookTimeScope.update(playbackPreferences, libraryPreferences)
+    BookTimeScope.update(book, playbackPreferences, libraryPreferences)
 
-    assertFalse(BookTimeScope.isBookTimeEnabled)
+    assertNull(BookTimeScope.book)
   }
 
   @Test
-  fun `disabled for a podcast library`() {
+  fun `empty for a podcast library`() {
     every { playbackPreferences.getShowBookTime() } returns true
     every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Podcasts", type = LibraryType.PODCAST)
 
-    BookTimeScope.update(playbackPreferences, libraryPreferences)
+    BookTimeScope.update(book, playbackPreferences, libraryPreferences)
 
-    assertFalse(BookTimeScope.isBookTimeEnabled)
+    assertNull(BookTimeScope.book)
   }
 
   @Test
-  fun `disabled when no library is preferred`() {
+  fun `empty when no library is preferred`() {
     every { playbackPreferences.getShowBookTime() } returns true
     every { libraryPreferences.getPreferredLibrary() } returns null
 
-    BookTimeScope.update(playbackPreferences, libraryPreferences)
+    BookTimeScope.update(book, playbackPreferences, libraryPreferences)
 
-    assertFalse(BookTimeScope.isBookTimeEnabled)
+    assertNull(BookTimeScope.book)
+  }
+
+  @Test
+  fun `empty when the prepared book has no chapters`() {
+    setScopeEnabled()
+
+    BookTimeScope.update(createBook(id = "book", chapterCount = 0), playbackPreferences, libraryPreferences)
+
+    assertNull(BookTimeScope.book)
+  }
+
+  private fun createBook(
+    id: String,
+    chapterCount: Int = 2,
+  ): DetailedItem {
+    val chapters =
+      (0 until chapterCount).map { index ->
+        PlayingChapter(
+          available = true,
+          podcastEpisodeState = null,
+          duration = 100.0,
+          start = index * 100.0,
+          end = (index + 1) * 100.0,
+          title = "$index",
+          id = "$index",
+        )
+      }
+
+    return DetailedItem(
+      id = id,
+      title = "",
+      subtitle = "",
+      author = "",
+      narrator = "",
+      publisher = "",
+      series = listOf(),
+      year = "",
+      abstract = "",
+      files = listOf(),
+      chapters = chapters,
+      progress = null,
+      libraryId = "lib",
+      localProvided = false,
+      createdAt = 0,
+      updatedAt = 0,
+    )
   }
 }

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/MediaRepositoryProgressScopeTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/MediaRepositoryProgressScopeTest.kt
@@ -2,92 +2,109 @@ package org.grakovne.lissen.playback
 
 import io.mockk.every
 import io.mockk.mockk
+import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.Library
 import org.grakovne.lissen.domain.LibraryType
 import org.grakovne.lissen.domain.PlayingChapter
 import org.grakovne.lissen.persistence.preferences.LibraryPreferences
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 /**
- * Specifies the scope branch in [MediaRepository.updateProgress]: the session player reports
- * book-scoped positions when the book-time snapshot is enabled, and chapter-scoped positions
- * otherwise, so the accumulated chapter offsets must only be added in chapter scope.
+ * Specifies the scope predicate [MediaRepository.updateProgress] branches on: book scope only
+ * when the [BookTimeScope] snapshot holds the same book that is playing. The player reaches the
+ * same conclusion through the mediaId cross-check in [BookTimeForwardingPlayer], so both fail
+ * closed to chapter scope together on a mismatch.
  *
  * [MediaRepository] depends on Android primitives (MediaController, Handler, Looper) and cannot
- * be instantiated in a JVM unit test, so the computation is mirrored here exactly as in
- * production and driven by the real [BookTimeScope] snapshot — the same convention used by
- * [MediaProgressUpdateLifecycleTest].
+ * be instantiated in a JVM unit test, so this pins the branch condition against the real
+ * snapshot rather than re-implementing the position arithmetic.
  */
 class MediaRepositoryProgressScopeTest {
   private val playbackPreferences = mockk<PlaybackPreferences>(relaxed = true)
   private val libraryPreferences = mockk<LibraryPreferences>(relaxed = true)
 
-  private val chapters =
-    (0 until 3).map { index ->
-      PlayingChapter(
-        available = true,
-        podcastEpisodeState = null,
-        duration = 100.0,
-        start = index * 100.0,
-        end = (index + 1) * 100.0,
-        title = "$index",
-        id = "$index",
-      )
-    }
+  private val book = createBook(id = "book")
+  private val otherBook = createBook(id = "other-book")
 
   @BeforeEach
   fun resetBookTimeScope() {
-    BookTimeScope.update(playbackPreferences, libraryPreferences)
+    BookTimeScope.update(book, playbackPreferences, libraryPreferences)
   }
 
-  private fun enableBookScope() {
+  private fun enableBookScope(book: DetailedItem = this.book) {
     every { playbackPreferences.getShowBookTime() } returns true
     every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
-    BookTimeScope.update(playbackPreferences, libraryPreferences)
+    BookTimeScope.update(book, playbackPreferences, libraryPreferences)
   }
 
-  private fun updateProgress(
-    currentMediaItemIndex: Int,
-    currentPositionMs: Long,
-  ): Double {
-    val accumulated = chapters.take(currentMediaItemIndex.coerceIn(0, chapters.size)).sumOf { it.duration }
-    val currentFilePosition = currentPositionMs / 1000.0
-
-    return if (BookTimeScope.isBookTimeEnabled) {
-      currentFilePosition
-    } else {
-      accumulated + currentFilePosition
-    }
-  }
+  private fun isBookScope(playingBook: DetailedItem): Boolean = BookTimeScope.book?.id == playingBook.id
 
   @Test
-  fun `chapter scope accumulates the offsets of the chapters before the current one`() {
-    assertEquals(250.0, updateProgress(currentMediaItemIndex = 2, currentPositionMs = 50_000L))
-  }
-
-  @Test
-  fun `chapter scope reports the raw chapter position in the first chapter`() {
-    assertEquals(50.0, updateProgress(currentMediaItemIndex = 0, currentPositionMs = 50_000L))
-  }
-
-  @Test
-  fun `book scope reports the controller position without accumulating chapter offsets`() {
+  fun `book scope when the snapshot holds the playing book`() {
     enableBookScope()
 
-    assertEquals(50.0, updateProgress(currentMediaItemIndex = 2, currentPositionMs = 50_000L))
+    assertTrue(isBookScope(book))
   }
 
   @Test
-  fun `the scope branch follows the snapshot, not the live preference`() {
-    every { playbackPreferences.getShowBookTime() } returns true
-    every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
-    BookTimeScope.update(playbackPreferences, libraryPreferences)
+  fun `chapter scope when the playing book differs from the snapshot book`() {
+    enableBookScope()
 
-    every { playbackPreferences.getShowBookTime() } returns false
+    assertFalse(isBookScope(otherBook))
+  }
 
-    assertEquals(50.0, updateProgress(currentMediaItemIndex = 2, currentPositionMs = 50_000L))
+  @Test
+  fun `chapter scope when the snapshot is empty`() {
+    // relaxed mocks: setting off, so the snapshot stays empty
+
+    assertFalse(isBookScope(book))
+  }
+
+  @Test
+  fun `chapter scope when the prepared book has no chapters`() {
+    enableBookScope(book = createBook(id = "book", chapterCount = 0))
+
+    assertFalse(isBookScope(book))
+  }
+
+  private fun createBook(
+    id: String,
+    chapterCount: Int = 2,
+  ): DetailedItem {
+    val chapters =
+      (0 until chapterCount).map { index ->
+        PlayingChapter(
+          available = true,
+          podcastEpisodeState = null,
+          duration = 100.0,
+          start = index * 100.0,
+          end = (index + 1) * 100.0,
+          title = "$index",
+          id = "$index",
+        )
+      }
+
+    return DetailedItem(
+      id = id,
+      title = "",
+      subtitle = "",
+      author = "",
+      narrator = "",
+      publisher = "",
+      series = listOf(),
+      year = "",
+      abstract = "",
+      files = listOf(),
+      chapters = chapters,
+      progress = null,
+      libraryId = "lib",
+      localProvided = false,
+      createdAt = 0,
+      updatedAt = 0,
+    )
   }
 }

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/MediaRepositoryProgressScopeTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/MediaRepositoryProgressScopeTest.kt
@@ -1,0 +1,93 @@
+package org.grakovne.lissen.playback
+
+import io.mockk.every
+import io.mockk.mockk
+import org.grakovne.lissen.domain.Library
+import org.grakovne.lissen.domain.LibraryType
+import org.grakovne.lissen.domain.PlayingChapter
+import org.grakovne.lissen.persistence.preferences.LibraryPreferences
+import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Specifies the scope branch in [MediaRepository.updateProgress]: the session player reports
+ * book-scoped positions when the book-time snapshot is enabled, and chapter-scoped positions
+ * otherwise, so the accumulated chapter offsets must only be added in chapter scope.
+ *
+ * [MediaRepository] depends on Android primitives (MediaController, Handler, Looper) and cannot
+ * be instantiated in a JVM unit test, so the computation is mirrored here exactly as in
+ * production and driven by the real [BookTimeScope] snapshot — the same convention used by
+ * [MediaProgressUpdateLifecycleTest].
+ */
+class MediaRepositoryProgressScopeTest {
+  private val playbackPreferences = mockk<PlaybackPreferences>(relaxed = true)
+  private val libraryPreferences = mockk<LibraryPreferences>(relaxed = true)
+
+  private val chapters =
+    (0 until 3).map { index ->
+      PlayingChapter(
+        available = true,
+        podcastEpisodeState = null,
+        duration = 100.0,
+        start = index * 100.0,
+        end = (index + 1) * 100.0,
+        title = "$index",
+        id = "$index",
+      )
+    }
+
+  @BeforeEach
+  fun resetBookTimeScope() {
+    BookTimeScope.update(playbackPreferences, libraryPreferences)
+  }
+
+  private fun enableBookScope() {
+    every { playbackPreferences.getShowBookTime() } returns true
+    every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
+    BookTimeScope.update(playbackPreferences, libraryPreferences)
+  }
+
+  private fun updateProgress(
+    currentMediaItemIndex: Int,
+    currentPositionMs: Long,
+  ): Double {
+    val accumulated = chapters.take(currentMediaItemIndex.coerceIn(0, chapters.size)).sumOf { it.duration }
+    val currentFilePosition = currentPositionMs / 1000.0
+
+    return if (BookTimeScope.isBookTimeEnabled) {
+      currentFilePosition
+    } else {
+      accumulated + currentFilePosition
+    }
+  }
+
+  @Test
+  fun `chapter scope accumulates the offsets of the chapters before the current one`() {
+    assertEquals(250.0, updateProgress(currentMediaItemIndex = 2, currentPositionMs = 50_000L))
+  }
+
+  @Test
+  fun `chapter scope reports the raw chapter position in the first chapter`() {
+    assertEquals(50.0, updateProgress(currentMediaItemIndex = 0, currentPositionMs = 50_000L))
+  }
+
+  @Test
+  fun `book scope reports the controller position without accumulating chapter offsets`() {
+    enableBookScope()
+
+    assertEquals(50.0, updateProgress(currentMediaItemIndex = 2, currentPositionMs = 50_000L))
+  }
+
+  @Test
+  fun `the scope branch follows the snapshot, not the live preference`() {
+    every { playbackPreferences.getShowBookTime() } returns true
+    every { libraryPreferences.getPreferredLibrary() } returns Library(id = "lib", title = "Books", type = LibraryType.LIBRARY)
+    BookTimeScope.update(playbackPreferences, libraryPreferences)
+
+    every { playbackPreferences.getShowBookTime() } returns false
+
+    assertEquals(50.0, updateProgress(currentMediaItemIndex = 2, currentPositionMs = 50_000L))
+  }
+}

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/MediaRepositoryProgressScopeTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/MediaRepositoryProgressScopeTest.kt
@@ -1,5 +1,8 @@
 package org.grakovne.lissen.playback
 
+import android.os.Bundle
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import io.mockk.every
 import io.mockk.mockk
 import org.grakovne.lissen.domain.DetailedItem
@@ -8,20 +11,20 @@ import org.grakovne.lissen.domain.LibraryType
 import org.grakovne.lissen.domain.PlayingChapter
 import org.grakovne.lissen.persistence.preferences.LibraryPreferences
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_START_MS
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 /**
- * Specifies the scope predicate [MediaRepository.updateProgress] branches on: book scope only
- * when the [BookTimeScope] snapshot holds the same book that is playing. The player reaches the
- * same conclusion through the mediaId cross-check in [BookTimeForwardingPlayer], so both fail
- * closed to chapter scope together on a mismatch.
- *
- * [MediaRepository] depends on Android primitives (MediaController, Handler, Looper) and cannot
- * be instantiated in a JVM unit test, so this pins the branch condition against the real
- * snapshot rather than re-implementing the position arithmetic.
+ * Specifies the shared book-time scope machinery that [MediaRepository.updateProgress] and
+ * [BookTimeForwardingPlayer] both run: [resolveBookTimeTranslation] is the one predicate (book
+ * scope only when the snapshot book matches the current item's mediaId and the item carries a
+ * valid CHAPTER_START_MS extra), and [bookTimeProgress] is the position arithmetic for both
+ * scopes. [MediaRepository] itself depends on Android primitives (MediaController, Handler,
+ * Looper) and cannot be instantiated in a JVM unit test, but these functions are the production
+ * code it calls, executed here for real.
  */
 class MediaRepositoryProgressScopeTest {
   private val playbackPreferences = mockk<PlaybackPreferences>(relaxed = true)
@@ -29,6 +32,7 @@ class MediaRepositoryProgressScopeTest {
 
   private val book = createBook(id = "book")
   private val otherBook = createBook(id = "other-book")
+  private val chapters = book.chapters
 
   @BeforeEach
   fun resetBookTimeScope() {
@@ -41,42 +45,84 @@ class MediaRepositoryProgressScopeTest {
     BookTimeScope.update(book, playbackPreferences, libraryPreferences)
   }
 
-  private fun isBookScope(playingBook: DetailedItem): Boolean = BookTimeScope.book?.id == playingBook.id
+  private fun chapterMediaItem(
+    mediaId: String = "chapter:book:0",
+    chapterStartMs: Long? = 100_000L,
+  ): MediaItem {
+    val metadata =
+      MediaMetadata
+        .Builder()
+        .apply {
+          chapterStartMs?.let {
+            val extras = mockk<Bundle>()
+            every { extras.getLong(CHAPTER_START_MS, -1) } returns it
+            setExtras(extras)
+          }
+        }.build()
+
+    return MediaItem
+      .Builder()
+      .setMediaId(mediaId)
+      .setMediaMetadata(metadata)
+      .build()
+  }
 
   @Test
-  fun `book scope when the snapshot holds the playing book`() {
+  fun `resolves the snapshot book when the media id matches and the item carries a chapter start`() {
     enableBookScope()
 
-    assertTrue(isBookScope(book))
+    val translation = resolveBookTimeTranslation(chapterMediaItem(), BookTimeScope.book)
+
+    assertEquals(book, translation?.book)
+    assertEquals(100_000L, translation?.chapterStartMs)
   }
 
   @Test
-  fun `chapter scope when the playing book differs from the snapshot book`() {
+  fun `null when the media id does not match the snapshot book`() {
     enableBookScope()
 
-    assertFalse(isBookScope(otherBook))
+    assertNull(resolveBookTimeTranslation(chapterMediaItem(mediaId = "chapter:other-book:0"), BookTimeScope.book))
   }
 
   @Test
-  fun `chapter scope when the snapshot is empty`() {
-    // relaxed mocks: setting off, so the snapshot stays empty
+  fun `null when the media id does not parse`() {
+    enableBookScope()
 
-    assertFalse(isBookScope(book))
+    assertNull(resolveBookTimeTranslation(chapterMediaItem(mediaId = "not-a-chapter-media-id"), BookTimeScope.book))
   }
 
   @Test
-  fun `chapter scope when the prepared book has no chapters`() {
-    enableBookScope(book = createBook(id = "book", chapterCount = 0))
+  fun `null when the item carries no chapter start extra`() {
+    enableBookScope()
 
-    assertFalse(isBookScope(book))
+    assertNull(resolveBookTimeTranslation(chapterMediaItem(chapterStartMs = null), BookTimeScope.book))
   }
 
-  private fun createBook(
-    id: String,
-    chapterCount: Int = 2,
-  ): DetailedItem {
+  @Test
+  fun `null when the snapshot is empty`() {
+    assertNull(resolveBookTimeTranslation(chapterMediaItem(), BookTimeScope.book))
+  }
+
+  @Test
+  fun `book scope position is the raw controller position without accumulated chapter offsets`() {
+    val translation = resolveBookTimeTranslation(chapterMediaItem(), book)
+
+    assertEquals(50.0, bookTimeProgress(translation, currentMediaItemIndex = 2, currentPositionMs = 50_000L, chapters = chapters))
+  }
+
+  @Test
+  fun `chapter scope position accumulates the offsets of the chapters before the current one`() {
+    assertEquals(250.0, bookTimeProgress(null, currentMediaItemIndex = 2, currentPositionMs = 50_000L, chapters = chapters))
+  }
+
+  @Test
+  fun `chapter scope position in the first chapter is the raw position`() {
+    assertEquals(50.0, bookTimeProgress(null, currentMediaItemIndex = 0, currentPositionMs = 50_000L, chapters = chapters))
+  }
+
+  private fun createBook(id: String): DetailedItem {
     val chapters =
-      (0 until chapterCount).map { index ->
+      (0 until 3).map { index ->
         PlayingChapter(
           available = true,
           podcastEpisodeState = null,

--- a/app/src/test/kotlin/org/grakovne/lissen/ui/extensions/TimeExtensionsTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/ui/extensions/TimeExtensionsTest.kt
@@ -82,4 +82,20 @@ class TimeExtensionsTest {
     assertEquals(0, parts.seconds)
     assertEquals(true, parts.includeSeconds)
   }
+
+  @Test
+  fun `speedCompensatedSeconds divides by the playback speed`() {
+    assertEquals(30.0, speedCompensatedSeconds(60.0, 2f))
+  }
+
+  @Test
+  fun `speedCompensatedSeconds keeps the raw value at one times speed`() {
+    assertEquals(60.0, speedCompensatedSeconds(60.0, 1f))
+  }
+
+  @Test
+  fun `speedCompensatedSeconds keeps the raw value when speed is not positive`() {
+    assertEquals(60.0, speedCompensatedSeconds(60.0, 0f))
+    assertEquals(60.0, speedCompensatedSeconds(60.0, -1.5f))
+  }
 }

--- a/app/src/test/kotlin/org/grakovne/lissen/ui/extensions/TimeExtensionsTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/ui/extensions/TimeExtensionsTest.kt
@@ -82,20 +82,4 @@ class TimeExtensionsTest {
     assertEquals(0, parts.seconds)
     assertEquals(true, parts.includeSeconds)
   }
-
-  @Test
-  fun `speedCompensatedSeconds divides by the playback speed`() {
-    assertEquals(30.0, speedCompensatedSeconds(60.0, 2f))
-  }
-
-  @Test
-  fun `speedCompensatedSeconds keeps the raw value at one times speed`() {
-    assertEquals(60.0, speedCompensatedSeconds(60.0, 1f))
-  }
-
-  @Test
-  fun `speedCompensatedSeconds keeps the raw value when speed is not positive`() {
-    assertEquals(60.0, speedCompensatedSeconds(60.0, 0f))
-    assertEquals(60.0, speedCompensatedSeconds(60.0, -1.5f))
-  }
 }

--- a/app/src/test/kotlin/org/grakovne/lissen/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/viewmodel/SettingsViewModelTest.kt
@@ -104,6 +104,7 @@ class SettingsViewModelTest {
     every { diagnostics.getAcraEnabled() } returns true
     every { connection.getSslBypass() } returns false
     every { playback.getSoftwareCodecsEnabled() } returns false
+    every { playback.getShowBookTimeRemaining() } returns false
     every { diagnostics.isActivityLoggingEnabled() } returns true
     every { download.getAutoDownloadDelayed() } returns false
     every { connection.getUserAgent() } returns DEFAULT_USER_AGENT
@@ -915,6 +916,14 @@ class SettingsViewModelTest {
 
       assertTrue(viewModel.softwareCodecsEnabled.value)
       verify { playback.saveSoftwareCodecsEnabled(true) }
+    }
+
+    @Test
+    fun `preferShowBookTimeRemaining updates StateFlow and preferences`() {
+      viewModel.preferShowBookTimeRemaining(true)
+
+      assertTrue(viewModel.showBookTimeRemaining.value)
+      verify { playback.saveShowBookTimeRemaining(true) }
     }
 
     @Test

--- a/app/src/test/kotlin/org/grakovne/lissen/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/viewmodel/SettingsViewModelTest.kt
@@ -104,7 +104,7 @@ class SettingsViewModelTest {
     every { diagnostics.getAcraEnabled() } returns true
     every { connection.getSslBypass() } returns false
     every { playback.getSoftwareCodecsEnabled() } returns false
-    every { playback.getShowBookTimeRemaining() } returns false
+    every { playback.getShowBookTime() } returns false
     every { diagnostics.isActivityLoggingEnabled() } returns true
     every { download.getAutoDownloadDelayed() } returns false
     every { connection.getUserAgent() } returns DEFAULT_USER_AGENT
@@ -919,11 +919,11 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `preferShowBookTimeRemaining updates StateFlow and preferences`() {
-      viewModel.preferShowBookTimeRemaining(true)
+    fun `preferShowBookTime updates StateFlow and preferences`() {
+      viewModel.preferShowBookTime(true)
 
-      assertTrue(viewModel.showBookTimeRemaining.value)
-      verify { playback.saveShowBookTimeRemaining(true) }
+      assertTrue(viewModel.showBookTime.value)
+      verify { playback.saveShowBookTime(true) }
     }
 
     @Test


### PR DESCRIPTION
> **Draft.** Rebuilt after @golinski found it broken on Android Auto. The media session part still needs a real controller before this is ready. See *Testing wanted* at the bottom.
>
> **Depends on #493.** That PR is merged into this branch, so its commits show in the diff until it lands upstream.

The player shows times for the **current chapter**. In a 13-hour book you can be seven hours in and see "10:14", which tells you very little. This adds an option to show times for the **whole book** instead.

### The option

A new toggle in Settings → Playback, **Show book time instead of chapter time**, off by default. Nothing changes unless you turn it on.

When it is on, everything that reports a time switches from chapter scope to book scope:

- The player screen's progress bar spans the whole book, and the elapsed and remaining labels follow it. Dragging seeks through the book and crosses chapter boundaries.
- Android Auto, the media notification and the lock screen report book position and book duration.

The details sheet already showed book duration and book remaining, so it keeps its content. The one edit there clamps "time remaining" at zero, so a position that runs slightly past the stored book duration cannot render a negative time.

The option only applies to book libraries. Podcast libraries always show episode time, because a sum across every episode is not a useful number. The toggle stays visible either way, since the setting is global and one server can hold both library types.

Two things stay chapter-scoped on purpose: the chapter list, where each row's duration is a fact about that row, and the skip buttons, which still move by one chapter.

### What was broken

The first version reported a book position against a chapter duration, so Android Auto clamped and drew a full bar. Two causes.

**The book could never be identified.** `BookTimeForwardingPlayer` resolved the book from `currentMediaItem.mediaId`. That mediaId did not exist at runtime: `BasePlayer.getCurrentMediaItem` reads the timeline window's item, which comes from the `MediaSource`, and `LissenMediaSourceFactory` built fresh items carrying only `mediaMetadata`. So the lookup returned null on every call. #493 fixes that by carrying the chapter item's identity onto the sources it builds, which is why this PR now depends on it.

**The two paths were gated differently.** The position path only needed the `CHAPTER_START_MS` extra, which did survive, while the duration path needed the book. So position translated and duration did not. That asymmetry was the actual defect, and the mediaId was only one way to trigger it — switching library, or a chapter with no resolvable files, would have done it too.

### How the media session part works now

The ExoPlayer playlist is one `MediaItem` per chapter, so the player's own position and duration are chapter-scoped by construction, and every controller inherits that.

`BookTimeForwardingPlayer` is a `ForwardingPlayer` that translates position and duration into book scope. It is used **only** where `MediaLibrarySessionProvider` builds the `MediaLibrarySession`. `PlaybackService`, `PlaybackSynchronizationService` and `PlaybackTimer` are injected with the raw `ExoPlayer` and are untouched, so progress reported to the server and the sleep timer keep working on real chapter values.

Scope is decided once, when a playlist is built, and stored in `BookTimeScope`. Position, duration, the seek reverse mapping and the app's own progress updater all go through one predicate, `resolveBookTimeTranslation`, which requires the snapshot book's id to match the current item's mediaId and the item to carry a valid `CHAPTER_START_MS`. Anything it cannot confirm falls back to chapter scope on every side at once, so the two can no longer disagree. The visible consequence is that toggling the option applies the next time a book is prepared rather than instantly, which also removes the previous mid-playback inconsistency, where controllers republish position on every state change but duration only on a media item or timeline change.

`MediaRepository.updateProgress` reads the `MediaController` and resolves the same predicate against the controller's view of the same timeline. It cannot use the raw position unconditionally, because the app's own controller is a client of the same session and would double-count.

### Behaviour change

`seekTo(long)` arriving from a controller is interpreted as a book position when the option is on. The incoming position is clamped to the book, and at or past the book end it seeks to the end of the last chapter, so scrubbing to the far right ends the book. `calculateChapterIndexAndPosition` maps a finished book back to the start of its last chapter, which is correct for resume and wrong for scrubbing, so that path is bypassed at the boundary and the function itself is untouched. `seekTo(int, long)` is deliberately left alone, because the app sends chapter-scoped values through it.

### Known limitation

Media3 sends controllers a book-scoped position block alongside a timeline that still describes chapters, and controllers are not consistent about which they trust when drawing a progress bar. This is documented in the class.

### Testing wanted

Unit tests cover the shared predicate, the translation, the reverse-mapped seek across a chapter boundary and at the book end, and every pass-through fallback, including the cases where the book cannot be confirmed and both sides have to agree to stay chapter-scoped. `lintKotlin` and `test` pass.

What I cannot test here is how real controllers render this. @golinski, if you have another Desktop Head Unit run in you, the things to look at are the progress bar length, the elapsed and remaining readouts, and whether scrubbing lands where you asked. Note that the option now takes effect when a book is next prepared, so toggle it and then start the book rather than expecting the car to change mid-chapter.
