### PR TITLE
Stop a stale resume from overwriting playback progress

### DIFF
--- a/app/schemas/org.grakovne.lissen.content.cache.persistent.LocalCacheStorage/22.json
+++ b/app/schemas/org.grakovne.lissen.content.cache.persistent.LocalCacheStorage/22.json
@@ -1,0 +1,443 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 22,
+    "identityHash": "f5bb8f932656514add5522727c576094",
+    "entities": [
+      {
+        "tableName": "detailed_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `subtitle` TEXT, `author` TEXT, `narrator` TEXT, `year` TEXT, `abstract` TEXT, `publisher` TEXT, `duration` INTEGER NOT NULL, `libraryId` TEXT, `seriesJson` TEXT, `seriesNames` TEXT, `seriesId` TEXT, `authorsJson` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "narrator",
+            "columnName": "narrator",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abstract",
+            "columnName": "abstract",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesJson",
+            "columnName": "seriesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesNames",
+            "columnName": "seriesNames",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "authorsJson",
+            "columnName": "authorsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_detailed_books_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_detailed_books_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          },
+          {
+            "name": "index_detailed_books_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_detailed_books_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookFileId` TEXT NOT NULL, `name` TEXT NOT NULL, `size` INTEGER NOT NULL, `duration` REAL NOT NULL, `mimeType` TEXT NOT NULL, `bookId` TEXT NOT NULL, FOREIGN KEY(`bookId`) REFERENCES `detailed_books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookFileId",
+            "columnName": "bookFileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_files_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_files_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "detailed_books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookChapterId` TEXT NOT NULL, `duration` REAL NOT NULL, `start` REAL NOT NULL, `end` REAL NOT NULL, `title` TEXT NOT NULL, `bookId` TEXT NOT NULL, `isCached` INTEGER NOT NULL, FOREIGN KEY(`bookId`) REFERENCES `detailed_books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookChapterId",
+            "columnName": "bookChapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "start",
+            "columnName": "start",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "end",
+            "columnName": "end",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCached",
+            "columnName": "isCached",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_chapters_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_chapters_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "detailed_books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "media_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `currentTime` REAL NOT NULL, `isFinished` INTEGER NOT NULL, `lastUpdate` INTEGER NOT NULL, `dirty` INTEGER NOT NULL, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentTime",
+            "columnName": "currentTime",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFinished",
+            "columnName": "isFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdate",
+            "columnName": "lastUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dirty",
+            "columnName": "dirty",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_progress_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_progress_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_bookmark",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `libraryItemId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `totalPosition` INTEGER NOT NULL, `syncState` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryItemId",
+            "columnName": "libraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPosition",
+            "columnName": "totalPosition",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_bookmark_libraryItemId",
+            "unique": false,
+            "columnNames": [
+              "libraryItemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_bookmark_libraryItemId` ON `${TABLE_NAME}` (`libraryItemId`)"
+          },
+          {
+            "name": "index_cached_bookmark_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_bookmark_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f5bb8f932656514add5522727c576094')"
+    ]
+  }
+}

--- a/app/src/androidTest/kotlin/org/grakovne/lissen/content/cache/persistent/LocalCacheStorageMigrationTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/content/cache/persistent/LocalCacheStorageMigrationTest.kt
@@ -200,6 +200,51 @@ class LocalCacheStorageMigrationTest {
   }
 
   @Test
+  fun migrate21To22_addsDirtyDefaultingToFalse_andKeepsExistingRows() {
+    helper.createDatabase(TEST_DB, 21).use { db ->
+      db.execSQL(
+        """
+        INSERT INTO detailed_books (id, title, duration, createdAt, updatedAt)
+        VALUES ('book-1', 'Dune', 0, 0, 0)
+        """.trimIndent(),
+      )
+      db.execSQL(
+        """
+        INSERT INTO media_progress (bookId, currentTime, isFinished, lastUpdate)
+        VALUES ('book-1', 12.0, 0, 0)
+        """.trimIndent(),
+      )
+    }
+
+    val db = helper.runMigrationsAndValidate(TEST_DB, 22, true, MIGRATION_21_22)
+
+    db.query("SELECT bookId, dirty FROM media_progress WHERE bookId = 'book-1'").use { cursor ->
+      assertTrue(cursor.moveToFirst())
+      assertEquals("book-1", cursor.getString(cursor.getColumnIndexOrThrow("bookId")))
+      assertEquals(0, cursor.getInt(cursor.getColumnIndexOrThrow("dirty")))
+    }
+  }
+
+  @Test
+  fun migrate21To22_allowsStoringDirtyFlag() {
+    helper.createDatabase(TEST_DB, 21).close()
+
+    val db = helper.runMigrationsAndValidate(TEST_DB, 22, true, MIGRATION_21_22)
+
+    db.execSQL(
+      """
+      INSERT INTO media_progress (bookId, currentTime, isFinished, lastUpdate, dirty)
+      VALUES ('book-2', 5.0, 0, 0, 1)
+      """.trimIndent(),
+    )
+
+    db.query("SELECT dirty FROM media_progress WHERE bookId = 'book-2'").use { cursor ->
+      assertTrue(cursor.moveToFirst())
+      assertEquals(1, cursor.getInt(cursor.getColumnIndexOrThrow("dirty")))
+    }
+  }
+
+  @Test
   fun migrateFrom14To19_appliesEveryMigrationInChain() {
     helper.createDatabase(TEST_DB, 14).use { db ->
       db.execSQL(

--- a/app/src/androidTest/kotlin/org/grakovne/lissen/content/cache/persistent/dao/CachedBookDaoProgressTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/content/cache/persistent/dao/CachedBookDaoProgressTest.kt
@@ -1,0 +1,124 @@
+package org.grakovne.lissen.content.cache.persistent.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.grakovne.lissen.content.cache.persistent.LocalCacheStorage
+import org.grakovne.lissen.domain.DetailedItem
+import org.grakovne.lissen.domain.MediaProgress
+import org.grakovne.lissen.domain.PlayingChapter
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CachedBookDaoProgressTest {
+  private lateinit var db: LocalCacheStorage
+  private lateinit var dao: CachedBookDao
+
+  @Before
+  fun setup() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    db =
+      Room
+        .inMemoryDatabaseBuilder(context, LocalCacheStorage::class.java)
+        .allowMainThreadQueries()
+        .build()
+    dao = db.cachedBookDao()
+  }
+
+  @After
+  fun teardown() = db.close()
+
+  private fun book(
+    id: String,
+    progress: MediaProgress?,
+  ): DetailedItem =
+    DetailedItem(
+      id = id,
+      title = "Book $id",
+      subtitle = null,
+      author = "Author",
+      narrator = null,
+      publisher = null,
+      series = emptyList(),
+      year = null,
+      abstract = null,
+      files = emptyList(),
+      progress = progress,
+      libraryId = LIBRARY,
+      localProvided = false,
+      createdAt = 0L,
+      updatedAt = 0L,
+      chapters =
+        listOf(
+          PlayingChapter(
+            id = "chapter-1",
+            title = "Chapter 1",
+            start = 0.0,
+            end = 100.0,
+            duration = 100.0,
+            available = true,
+            podcastEpisodeState = null,
+          ),
+        ),
+    )
+
+  @Test
+  fun dirtyProgressSurvivesCachingRunCarryingOlderProgress() =
+    runBlocking {
+      val id = "book-1"
+      dao.upsertCachedBook(
+        book(id, MediaProgress(currentTime = 100.0, isFinished = false, lastUpdate = 2_000, dirty = true)),
+        emptyList(),
+        emptyList(),
+      )
+
+      dao.upsertCachedBook(
+        book(id, MediaProgress(currentTime = 10.0, isFinished = false, lastUpdate = 1_000, dirty = false)),
+        emptyList(),
+        emptyList(),
+      )
+
+      val progress = dao.fetchMediaProgress(id)
+      assertNotNull(progress)
+      assertEquals(100.0, progress!!.currentTime, 0.0)
+      assertEquals(2_000, progress.lastUpdate)
+      assertTrue(progress.dirty)
+
+      // The rest of the upsert is unaffected.
+      assertNotNull(dao.fetchCachedBook(id))
+    }
+
+  @Test
+  fun nonDirtyProgressIsReplacedByCachingRun() =
+    runBlocking {
+      val id = "book-2"
+      dao.upsertCachedBook(
+        book(id, MediaProgress(currentTime = 50.0, isFinished = false, lastUpdate = 1_500, dirty = false)),
+        emptyList(),
+        emptyList(),
+      )
+
+      dao.upsertCachedBook(
+        book(id, MediaProgress(currentTime = 10.0, isFinished = false, lastUpdate = 1_000, dirty = false)),
+        emptyList(),
+        emptyList(),
+      )
+
+      val progress = dao.fetchMediaProgress(id)
+      assertNotNull(progress)
+      assertEquals(10.0, progress!!.currentTime, 0.0)
+      assertEquals(1_000, progress.lastUpdate)
+    }
+
+  companion object {
+    private const val LIBRARY = "lib-1"
+  }
+}

--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallbackTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallbackTest.kt
@@ -69,6 +69,10 @@ class MediaLibrarySessionCallbackTest {
     session = mockk(relaxed = true)
     controller = mockk(relaxed = true)
 
+    // The provider is mocked here; on the resumption path its overlay is what
+    // restores the locally recorded progress, so default it to an identity.
+    coEvery { lissenMediaProvider.overlayLocalProgress(any()) } answers { firstArg() }
+
     callback =
       MediaLibrarySessionCallback(
         context,
@@ -227,6 +231,28 @@ class MediaLibrarySessionCallbackTest {
       verify(exactly = 1) { preferences.savePlayingItem(refreshedBook) }
       verify(exactly = 1) { playbackSynchronizationService.startPlaybackSynchronization(refreshedBook) }
       verify(exactly = 1) { mediaRepository.registerPlayingBook(refreshedBook) }
+    }
+
+  @Test
+  fun onPlaybackResumption_localOverlayProgress_resumesAtOverlaidPosition() =
+    runBlocking {
+      val storedBook = makeDetailedItem("book-1", "My Book", MediaProgress(170.0, false, 0L))
+      val overlaidBook = makeDetailedItem("book-1", "My Book", MediaProgress(270.0, false, 0L))
+      every { preferences.getPlayingItem() } returns storedBook
+      coEvery { lissenMediaProvider.fetchBook("book-1") } returns
+        OperationResult.Error(OperationError.NotFoundError)
+      coEvery { lissenMediaProvider.overlayLocalProgress(any()) } returns overlaidBook
+
+      val result =
+        callback
+          .onPlaybackResumption(session, controller, isForPlayback = true)
+          .get(5, TimeUnit.SECONDS)
+
+      assertEquals(listOf("chapter:book-1:0", "chapter:book-1:1"), result.mediaItems.map { it.mediaId })
+      assertEquals(1, result.startIndex)
+      assertEquals(120000, result.startPositionMs)
+      verify(exactly = 1) { playbackSynchronizationService.startPlaybackSynchronization(overlaidBook) }
+      verify(exactly = 1) { mediaRepository.registerPlayingBook(overlaidBook) }
     }
 
   @Test

--- a/app/src/main/kotlin/org/grakovne/lissen/content/LissenMediaProvider.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/LissenMediaProvider.kt
@@ -22,6 +22,7 @@ import org.grakovne.lissen.domain.PlaybackSession
 import org.grakovne.lissen.domain.RecentBook
 import org.grakovne.lissen.domain.UserAccount
 import org.grakovne.lissen.persistence.preferences.LibraryPreferences
+import org.grakovne.lissen.playback.service.adjustToFirstAvailableChapter
 import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
@@ -94,6 +95,21 @@ class LissenMediaProvider
       }
     }
 
+    /**
+     * Persists the playback progress into the local cache, marking it dirty.
+     * Does not touch the server; the sync path calls this before any network
+     * work so the local write survives even when the sync never completes.
+     */
+    suspend fun syncProgressLocally(
+      detailedItem: DetailedItem,
+      progress: PlaybackProgress,
+    ) {
+      Timber.d(
+        "Persisting progress locally: bookId=${detailedItem.id}, totalTime=${progress.currentTotalTime.toInt()}s",
+      )
+      localCacheRepository.syncProgress(detailedItem, progress)
+    }
+
     suspend fun syncProgress(
       sessionId: String,
       detailedItem: DetailedItem,
@@ -104,12 +120,16 @@ class LissenMediaProvider
         "Syncing progress: bookId=${detailedItem.id}, totalTime=${progress.currentTotalTime.toInt()}s, listened=${timeListened.toInt()}s",
       )
 
-      localCacheRepository.syncProgress(detailedItem, progress)
-
+      // In offline mode the server never sees the value, so the local row must
+      // stay dirty. Do not clear the dirty flag on this short-circuit.
       if (preferences.isForceCache()) return OperationResult.Success(Unit)
 
       return providePreferredChannel()
         .syncProgress(sessionId, progress, timeListened)
+        .map {
+          localCacheRepository.markProgressSynced(detailedItem.id)
+          Unit
+        }
     }
 
     suspend fun fetchBookCover(bookId: String): OperationResult<File> {
@@ -337,6 +357,7 @@ class LissenMediaProvider
               onFailure = { error ->
                 localCacheRepository
                   .fetchBook(bookId)
+                  ?.let { mergeLocalItemProgress(it) }
                   ?.let { OperationResult.Success(it) }
                   ?: error
               },
@@ -461,14 +482,33 @@ class LissenMediaProvider
       }
     }
 
+    /**
+     * Overlays the locally recorded progress (the media_progress row) onto the
+     * given item. Used on restore paths where the network snapshot may be
+     * stale or unreachable, so an offline resume lands on the position that
+     * was actually played. The resulting position is guaranteed to point at an
+     * available chapter, mirroring [LocalCacheRepository.fetchBook].
+     */
+    suspend fun overlayLocalProgress(book: DetailedItem): DetailedItem = mergeLocalItemProgress(book)
+
     private suspend fun mergeLocalItemProgress(detailedItem: DetailedItem): DetailedItem {
       val cachedProgress = localCacheRepository.fetchPlayingItemProgress(detailedItem.id)
       val channelProgress = detailedItem.progress
 
+      // A locally recorded progress that has not been synced to the server yet
+      // wins outright; it reflects the actual playback position.
       val updatedProgress =
-        listOfNotNull(cachedProgress, channelProgress)
-          .maxByOrNull { it.lastUpdate }
-          ?: return detailedItem
+        when {
+          cachedProgress?.dirty == true -> {
+            cachedProgress
+          }
+
+          else -> {
+            listOfNotNull(cachedProgress, channelProgress)
+              .maxByOrNull { it.lastUpdate }
+              ?: return detailedItem
+          }
+        }
 
       Timber.d(
         """
@@ -479,7 +519,13 @@ class LissenMediaProvider
         """.trimIndent(),
       )
 
-      return detailedItem.copy(progress = updatedProgress)
+      val merged = detailedItem.copy(progress = updatedProgress)
+
+      // The merged position must point at a chapter the player can actually
+      // play; a dirty row recorded on a chapter that is not cached would
+      // otherwise resume into a remote URI while offline. The adjustment is a
+      // no-op when the current chapter is available.
+      return merged.adjustToFirstAvailableChapter() ?: merged
     }
 
     fun fetchConnectionHost() = providePreferredChannel().fetchConnectionHost()

--- a/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/LocalCacheModule.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/LocalCacheModule.kt
@@ -50,6 +50,7 @@ object LocalCacheModule {
       .addMigrations(MIGRATION_18_19)
       .addMigrations(MIGRATION_19_20)
       .addMigrations(MIGRATION_20_21)
+      .addMigrations(MIGRATION_21_22)
       .build()
   }
 

--- a/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/LocalCacheRepository.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/LocalCacheRepository.kt
@@ -13,12 +13,11 @@ import org.grakovne.lissen.domain.Bookmark
 import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.Library
 import org.grakovne.lissen.domain.LibraryEntry
-import org.grakovne.lissen.domain.MediaProgress
 import org.grakovne.lissen.domain.PagedItems
 import org.grakovne.lissen.domain.PlaybackProgress
 import org.grakovne.lissen.domain.RecentBook
 import org.grakovne.lissen.domain.asLibraryEntries
-import org.grakovne.lissen.playback.service.calculateChapterIndex
+import org.grakovne.lissen.playback.service.adjustToFirstAvailableChapter
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -49,6 +48,10 @@ class LocalCacheRepository
     ): OperationResult<Unit> {
       cachedBookRepository.syncProgress(detailedItem, progress)
       return OperationResult.Success(Unit)
+    }
+
+    suspend fun markProgressSynced(bookId: String) {
+      cachedBookRepository.markProgressSynced(bookId)
     }
 
     fun fetchBookCover(bookId: String): OperationResult<File> {
@@ -196,50 +199,19 @@ class LocalCacheRepository
      * Fetches a detailed book item by its ID from the cached repository.
      * If the book is not found in the cache, returns `null`.
      *
-     * The method ensures that the book's playback position points to an available chapter:
+     * The method ensures that the book's playback position points to an available chapter
+     * via [adjustToFirstAvailableChapter]:
      * - If the current chapter is available, the cached book is returned as is.
      * - If the current chapter is unavailable, the playback progress is adjusted to the first available chapter.
      *
      * @param bookId the unique identifier of the book to fetch.
      * @return the detailed book item with updated playback progress if necessary,
-     *         or `null` if the book is not found in the cache.
+     *         or `null` if the book is not found in the cache or no chapter is available.
      */
-    suspend fun fetchBook(bookId: String): DetailedItem? {
-      val cachedBook =
-        cachedBookRepository
-          .fetchBook(bookId)
-          ?: return null
-
-      val cachedPosition =
-        cachedBook
-          .progress
-          ?.currentTime
-          ?: 0.0
-
-      val currentChapter = calculateChapterIndex(cachedBook, cachedPosition)
-
-      return when (currentChapter in cachedBook.chapters.indices && cachedBook.chapters[currentChapter].available) {
-        true -> {
-          cachedBook
-        }
-
-        false -> {
-          cachedBook
-            .copy(
-              progress =
-                MediaProgress(
-                  currentTime =
-                    cachedBook.chapters
-                      .firstOrNull { it.available }
-                      ?.start
-                      ?: return null,
-                  isFinished = false,
-                  lastUpdate = 946728000000, // 2000-01-01T12:00
-                ),
-            )
-        }
-      }
-    }
+    suspend fun fetchBook(bookId: String): DetailedItem? =
+      cachedBookRepository
+        .fetchBook(bookId)
+        ?.adjustToFirstAvailableChapter()
 
     suspend fun fetchBookmarks(libraryItemId: String) =
       cachedBookmarkRepository

--- a/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/LocalCacheStorage.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/LocalCacheStorage.kt
@@ -21,7 +21,7 @@ import org.grakovne.lissen.content.cache.persistent.entity.MediaProgressEntity
     CachedLibraryEntity::class,
     CachedBookmarkEntity::class,
   ],
-  version = 21,
+  version = 22,
   exportSchema = true,
 )
 abstract class LocalCacheStorage : RoomDatabase() {

--- a/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/Migrations.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/Migrations.kt
@@ -379,3 +379,15 @@ val MIGRATION_20_21 =
       db.execSQL("CREATE INDEX IF NOT EXISTS index_detailed_books_seriesId ON detailed_books(seriesId)")
     }
   }
+
+val MIGRATION_21_22 =
+  object : Migration(21, 22) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+      db.execSQL(
+        """
+        ALTER TABLE media_progress
+        ADD COLUMN dirty INTEGER NOT NULL DEFAULT 0
+        """.trimIndent(),
+      )
+    }
+  }

--- a/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/api/CachedBookRepository.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/api/CachedBookRepository.kt
@@ -403,9 +403,18 @@ class CachedBookRepository
           currentTime = progress.currentTotalTime,
           isFinished = progress.currentTotalTime >= totalDuration - FINISHED_POSITION_EPSILON,
           lastUpdate = Instant.now().toEpochMilli(),
+          dirty = true,
         )
 
       bookDao.upsertMediaProgress(entity)
+    }
+
+    /**
+     * Clears the dirty flag after the progress for this book has been
+     * acknowledged by the server. The row keeps its current values.
+     */
+    suspend fun markProgressSynced(bookId: String) {
+      bookDao.markMediaProgressSynced(bookId)
     }
 
     private fun buildOrdering(): Pair<String, String> {

--- a/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/converter/MediaProgressEntityConverter.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/converter/MediaProgressEntityConverter.kt
@@ -14,5 +14,6 @@ class MediaProgressEntityConverter
         currentTime = entity.currentTime,
         isFinished = entity.isFinished,
         lastUpdate = entity.lastUpdate,
+        dirty = entity.dirty,
       )
   }

--- a/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/dao/CachedBookDao.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/dao/CachedBookDao.kt
@@ -115,6 +115,8 @@ interface CachedBookDao {
           )
         }
 
+    val existingProgress = fetchMediaProgress(book.id)
+
     val mediaProgress =
       book
         .progress
@@ -124,13 +126,19 @@ interface CachedBookDao {
             currentTime = progress.currentTime,
             isFinished = progress.isFinished,
             lastUpdate = progress.lastUpdate,
+            dirty = progress.dirty,
           )
         }
 
     upsertBook(bookEntity)
     upsertBookFiles(bookFiles)
     upsertBookChapters(bookChapters)
-    mediaProgress?.let { upsertMediaProgress(it) }
+
+    // Never let a caching run clobber a locally recorded progress that has
+    // not been synced to the server yet.
+    if (existingProgress?.dirty != true) {
+      mediaProgress?.let { upsertMediaProgress(it) }
+    }
   }
 
   @Transaction
@@ -250,6 +258,9 @@ interface CachedBookDao {
 
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun upsertMediaProgress(progress: MediaProgressEntity)
+
+  @Query("UPDATE media_progress SET dirty = 0 WHERE bookId = :bookId")
+  suspend fun markMediaProgressSynced(bookId: String)
 
   @Transaction
   @Query("SELECT * FROM media_progress WHERE bookId = :bookId")

--- a/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/entity/CachedBookEntity.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/cache/persistent/entity/CachedBookEntity.kt
@@ -116,6 +116,7 @@ data class MediaProgressEntity(
   val currentTime: Double,
   val isFinished: Boolean,
   val lastUpdate: Long,
+  val dirty: Boolean = false,
 ) : Serializable
 
 @Keep

--- a/app/src/main/kotlin/org/grakovne/lissen/domain/DetailedItem.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/domain/DetailedItem.kt
@@ -46,6 +46,7 @@ data class MediaProgress(
   val currentTime: Double,
   val isFinished: Boolean,
   val lastUpdate: Long,
+  val dirty: Boolean = false,
 ) : Serializable
 
 @Keep

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallback.kt
@@ -262,7 +262,10 @@ class MediaLibrarySessionCallback
               ?: throw IllegalStateException("No last played book stored")
 
           val refreshedBook = refreshBookForResumption(storedBook)
-          val book = refreshedBook ?: storedBook
+          // The refreshed book already carries the merged local progress; when
+          // it is unavailable (offline), overlay the locally recorded progress
+          // onto the stored snapshot so resumption lands at the real position.
+          val book = lissenMediaProvider.overlayLocalProgress(refreshedBook ?: storedBook)
 
           if (book.canProducePlaybackQueue().not()) {
             throw IllegalStateException("Book can't produce a playback queue (bookId=${book.id})")

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/CalculateChapterIndexAndPosition.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/CalculateChapterIndexAndPosition.kt
@@ -1,6 +1,39 @@
 package org.grakovne.lissen.playback.service
 
 import org.grakovne.lissen.domain.DetailedItem
+import org.grakovne.lissen.domain.MediaProgress
+
+/**
+ * Returns a copy of the item whose progress points at an available chapter.
+ * When the recorded position points at an unavailable chapter, the progress
+ * is adjusted to the start of the first available chapter. Returns `null`
+ * when no chapter is available at all.
+ */
+fun DetailedItem.adjustToFirstAvailableChapter(): DetailedItem? {
+  val recordedPosition = progress?.currentTime ?: 0.0
+  val currentChapter = calculateChapterIndex(this, recordedPosition)
+
+  return when (currentChapter in chapters.indices && chapters[currentChapter].available) {
+    true -> {
+      this
+    }
+
+    false -> {
+      chapters
+        .firstOrNull { it.available }
+        ?.let { firstAvailable ->
+          copy(
+            progress =
+              MediaProgress(
+                currentTime = firstAvailable.start,
+                isFinished = false,
+                lastUpdate = 946728000000, // 2000-01-01T12:00
+              ),
+          )
+        }
+    }
+  }
+}
 
 fun calculateChapterPosition(
   book: DetailedItem,

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackSynchronizationService.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackSynchronizationService.kt
@@ -23,6 +23,7 @@ import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_ST
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.abs
 
 @Singleton
 class PlaybackSynchronizationService
@@ -36,6 +37,7 @@ class PlaybackSynchronizationService
     private var currentChapterIndex: Int? = null
     private var playbackSession: PlaybackSession? = null
     private var listeningMark = ListeningMark(playingSince = null, unsyncedMs = 0)
+    private var restoredStartPosition: Double? = null
     private val serviceScope = MainScope()
     private var syncJob: Job? = null
     private val syncRunner = CoalescingRunner<SyncSnapshot>()
@@ -60,6 +62,7 @@ class PlaybackSynchronizationService
       serviceScope.coroutineContext.cancelChildren()
       syncJob = null
       currentItem = item
+      restoredStartPosition = item.progress?.currentTime
       listeningMark = listeningMark.copy(playingSince = null)
     }
 
@@ -105,6 +108,17 @@ class PlaybackSynchronizationService
 
       listeningMark = accumulateListening(listeningMark, exoPlayer.isPlaying, SystemClock.elapsedRealtime())
 
+      if (isRestoredPositionUnchanged(restoredStartPosition, overallProgress.currentTotalTime, listeningMark.unsyncedMs)) {
+        Timber.d("Skipping sync for ${currentItem.id} due to position is still the restored start position")
+        return
+      }
+
+      // The gate is one-shot per item: the first unsuppressed sync (playing,
+      // seeking, or any other activity) clears the restored start position so the
+      // gate can never re-engage for this item, e.g. when the user later pauses
+      // back at the restored start position.
+      restoredStartPosition = null
+
       val snapshot =
         SyncSnapshot(
           progress = overallProgress,
@@ -127,6 +141,11 @@ class PlaybackSynchronizationService
       snapshot: SyncSnapshot,
     ) {
       val currentIndex = calculateChapterIndex(currentItem, snapshot.progress.currentTotalTime)
+
+      // Persist the position locally before any network work so the write
+      // survives a process kill mid-sync. The row is marked dirty until the
+      // server POST below succeeds.
+      mediaChannel.syncProgressLocally(currentItem, snapshot.progress)
 
       if (playbackSession == null ||
         playbackSession?.itemId != currentItem.id ||
@@ -208,6 +227,7 @@ class PlaybackSynchronizationService
           Player.EVENT_MEDIA_ITEM_TRANSITION,
           Player.EVENT_PLAYBACK_STATE_CHANGED,
           Player.EVENT_IS_PLAYING_CHANGED,
+          Player.EVENT_POSITION_DISCONTINUITY,
         )
     }
   }
@@ -221,6 +241,21 @@ internal const val SYNC_INTERVAL_LONG = 45_000L
 internal const val SYNC_INTERVAL_SHORT = 5_000L
 
 private const val SHORT_SYNC_WINDOW_MS = 90_000L
+private const val RESTORED_POSITION_TOLERANCE_SECONDS = 0.1
+
+/**
+ * True when the player still sits on the position the current item was restored to
+ * and no listening time has accumulated yet. In that state the position carries no
+ * new information, so syncing it would only write the just-restored value back.
+ */
+internal fun isRestoredPositionUnchanged(
+  restoredStartPosition: Double?,
+  currentPosition: Double,
+  unsyncedMs: Long,
+): Boolean =
+  restoredStartPosition != null &&
+    unsyncedMs == 0L &&
+    abs(currentPosition - restoredStartPosition) <= RESTORED_POSITION_TOLERANCE_SECONDS
 
 internal fun chooseSyncInterval(
   durationMs: Long,

--- a/app/src/test/kotlin/org/grakovne/lissen/content/LissenMediaProviderTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/content/LissenMediaProviderTest.kt
@@ -22,6 +22,7 @@ import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.Library
 import org.grakovne.lissen.domain.LibraryEntry
 import org.grakovne.lissen.domain.LibraryType
+import org.grakovne.lissen.domain.MediaProgress
 import org.grakovne.lissen.domain.PagedItems
 import org.grakovne.lissen.domain.PlaybackProgress
 import org.grakovne.lissen.domain.PlaybackSession
@@ -151,6 +152,236 @@ class LissenMediaProviderTest {
         provider.fetchBook("book-1")
 
         coVerify(exactly = 0) { localCacheRepository.fetchBook(any()) }
+      }
+
+    @Test
+    fun `overlays dirty local progress onto the cached copy when the channel fails`() =
+      runBlocking {
+        val cachedItem =
+          detailedItem(
+            "book-1",
+            progress = MediaProgress(currentTime = 10.0, isFinished = false, lastUpdate = 100),
+          )
+        val localProgress = MediaProgress(currentTime = 500.0, isFinished = false, lastUpdate = 200, dirty = true)
+        every { preferences.isForceCache() } returns false
+        coEvery { mediaChannel.fetchBook("book-1") } returns
+          OperationResult.Error(OperationError.NetworkError)
+        coEvery { localCacheRepository.fetchBook("book-1") } returns cachedItem
+        coEvery { localCacheRepository.fetchPlayingItemProgress("book-1") } returns localProgress
+
+        val result = provider.fetchBook("book-1")
+
+        assertEquals(localProgress, (result as OperationResult.Success).data.progress)
+      }
+
+    @Test
+    fun `keeps newer local progress when the channel fails and the row is not dirty`() =
+      runBlocking {
+        val cachedItem =
+          detailedItem(
+            "book-1",
+            progress = MediaProgress(currentTime = 10.0, isFinished = false, lastUpdate = 100),
+          )
+        val localProgress = MediaProgress(currentTime = 500.0, isFinished = false, lastUpdate = 200, dirty = false)
+        every { preferences.isForceCache() } returns false
+        coEvery { mediaChannel.fetchBook("book-1") } returns
+          OperationResult.Error(OperationError.NetworkError)
+        coEvery { localCacheRepository.fetchBook("book-1") } returns cachedItem
+        coEvery { localCacheRepository.fetchPlayingItemProgress("book-1") } returns localProgress
+
+        val result = provider.fetchBook("book-1")
+
+        assertEquals(localProgress, (result as OperationResult.Success).data.progress)
+      }
+
+    @Test
+    fun `dirty local progress wins over a newer channel progress`() =
+      runBlocking {
+        val chapters =
+          listOf(
+            PlayingChapter(
+              available = true,
+              podcastEpisodeState = null,
+              duration = 1000.0,
+              start = 0.0,
+              end = 1000.0,
+              title = "Chapter",
+              id = "c1",
+            ),
+          )
+        val channelItem =
+          detailedItem(
+            "book-1",
+            chapters = chapters,
+            progress = MediaProgress(currentTime = 10.0, isFinished = false, lastUpdate = 999),
+          )
+        val localProgress = MediaProgress(currentTime = 500.0, isFinished = false, lastUpdate = 100, dirty = true)
+        every { preferences.isForceCache() } returns false
+        coEvery { mediaChannel.fetchBook("book-1") } returns OperationResult.Success(channelItem)
+        coEvery { localCacheRepository.fetchPlayingItemProgress("book-1") } returns localProgress
+
+        val result = provider.fetchBook("book-1")
+
+        assertEquals(localProgress, (result as OperationResult.Success).data.progress)
+      }
+
+    @Test
+    fun `adjusts the overlaid dirty progress to the first available chapter when the channel fails`() =
+      runBlocking {
+        val chapters =
+          listOf(
+            PlayingChapter(
+              available = true,
+              podcastEpisodeState = null,
+              duration = 300.0,
+              start = 0.0,
+              end = 300.0,
+              title = "Chapter 1",
+              id = "c1",
+            ),
+            PlayingChapter(
+              available = false,
+              podcastEpisodeState = null,
+              duration = 300.0,
+              start = 300.0,
+              end = 600.0,
+              title = "Chapter 2",
+              id = "c2",
+            ),
+          )
+        val cachedItem =
+          detailedItem(
+            "book-1",
+            chapters = chapters,
+            progress = MediaProgress(currentTime = 0.0, isFinished = false, lastUpdate = 100),
+          )
+        val localProgress = MediaProgress(currentTime = 450.0, isFinished = false, lastUpdate = 200, dirty = true)
+        every { preferences.isForceCache() } returns false
+        coEvery { mediaChannel.fetchBook("book-1") } returns
+          OperationResult.Error(OperationError.NetworkError)
+        coEvery { localCacheRepository.fetchBook("book-1") } returns cachedItem
+        coEvery { localCacheRepository.fetchPlayingItemProgress("book-1") } returns localProgress
+
+        val result = provider.fetchBook("book-1")
+
+        val data = (result as OperationResult.Success).data
+        assertEquals(0.0, data.progress?.currentTime)
+      }
+  }
+
+  @Nested
+  inner class OverlayLocalProgress {
+    @Test
+    fun `returns the book unchanged when there is no local progress row`() =
+      runBlocking {
+        val item =
+          detailedItem(
+            "book-1",
+            progress = MediaProgress(currentTime = 10.0, isFinished = false, lastUpdate = 100),
+          )
+        coEvery { localCacheRepository.fetchPlayingItemProgress("book-1") } returns null
+
+        val result = provider.overlayLocalProgress(item)
+
+        assertEquals(10.0, result.progress?.currentTime)
+      }
+
+    @Test
+    fun `dirty local progress wins outright even when the book progress is newer`() =
+      runBlocking {
+        val item =
+          detailedItem(
+            "book-1",
+            progress = MediaProgress(currentTime = 10.0, isFinished = false, lastUpdate = 999),
+          )
+        coEvery { localCacheRepository.fetchPlayingItemProgress("book-1") } returns
+          MediaProgress(currentTime = 500.0, isFinished = false, lastUpdate = 100, dirty = true)
+
+        val result = provider.overlayLocalProgress(item)
+
+        assertEquals(500.0, result.progress?.currentTime)
+      }
+
+    @Test
+    fun `newest lastUpdate wins when the local row is not dirty`() =
+      runBlocking {
+        val item =
+          detailedItem(
+            "book-1",
+            progress = MediaProgress(currentTime = 10.0, isFinished = false, lastUpdate = 100),
+          )
+        coEvery { localCacheRepository.fetchPlayingItemProgress("book-1") } returns
+          MediaProgress(currentTime = 500.0, isFinished = false, lastUpdate = 200, dirty = false)
+
+        val result = provider.overlayLocalProgress(item)
+
+        assertEquals(500.0, result.progress?.currentTime)
+      }
+
+    @Test
+    fun `book progress wins when it is newer and the local row is not dirty`() =
+      runBlocking {
+        val item =
+          detailedItem(
+            "book-1",
+            progress = MediaProgress(currentTime = 10.0, isFinished = false, lastUpdate = 999),
+          )
+        coEvery { localCacheRepository.fetchPlayingItemProgress("book-1") } returns
+          MediaProgress(currentTime = 500.0, isFinished = false, lastUpdate = 100, dirty = false)
+
+        val result = provider.overlayLocalProgress(item)
+
+        assertEquals(10.0, result.progress?.currentTime)
+      }
+
+    @Test
+    fun `applies when the book has no progress at all`() =
+      runBlocking {
+        val item = detailedItem("book-1", progress = null)
+        coEvery { localCacheRepository.fetchPlayingItemProgress("book-1") } returns
+          MediaProgress(currentTime = 500.0, isFinished = false, lastUpdate = 100)
+
+        val result = provider.overlayLocalProgress(item)
+
+        assertEquals(500.0, result.progress?.currentTime)
+      }
+
+    @Test
+    fun `adjusts to the first available chapter when the dirty progress points at an uncached chapter`() =
+      runBlocking {
+        val chapters =
+          listOf(
+            PlayingChapter(
+              available = true,
+              podcastEpisodeState = null,
+              duration = 300.0,
+              start = 0.0,
+              end = 300.0,
+              title = "Chapter 1",
+              id = "c1",
+            ),
+            PlayingChapter(
+              available = false,
+              podcastEpisodeState = null,
+              duration = 300.0,
+              start = 300.0,
+              end = 600.0,
+              title = "Chapter 2",
+              id = "c2",
+            ),
+          )
+        val item =
+          detailedItem(
+            "book-1",
+            chapters = chapters,
+            progress = MediaProgress(currentTime = 0.0, isFinished = false, lastUpdate = 100),
+          )
+        coEvery { localCacheRepository.fetchPlayingItemProgress("book-1") } returns
+          MediaProgress(currentTime = 450.0, isFinished = false, lastUpdate = 200, dirty = true)
+
+        val result = provider.overlayLocalProgress(item)
+
+        assertEquals(0.0, result.progress?.currentTime)
       }
   }
 
@@ -495,7 +726,7 @@ class LissenMediaProviderTest {
   @Nested
   inner class SyncProgress {
     @Test
-    fun `syncs local cache without calling channel when force cache enabled`() =
+    fun `returns success without network call or clearing dirty when force cache enabled`() =
       runBlocking {
         val item = detailedItem("book-1")
         val progress = PlaybackProgress(currentChapterTime = 10.0, currentTotalTime = 100.0)
@@ -504,12 +735,13 @@ class LissenMediaProviderTest {
         val result = provider.syncProgress("session-1", item, progress, 42.0)
 
         assertInstanceOf(OperationResult.Success::class.java, result)
-        coVerify { localCacheRepository.syncProgress(item, progress) }
         coVerify(exactly = 0) { mediaChannel.syncProgress(any(), any(), any()) }
+        coVerify(exactly = 0) { localCacheRepository.syncProgress(any(), any()) }
+        coVerify(exactly = 0) { localCacheRepository.markProgressSynced(any()) }
       }
 
     @Test
-    fun `syncs local cache when force cache disabled`() =
+    fun `posts to the channel and clears dirty when force cache disabled`() =
       runBlocking {
         val item = detailedItem("book-1")
         val progress = PlaybackProgress(currentChapterTime = 10.0, currentTotalTime = 100.0)
@@ -519,8 +751,9 @@ class LissenMediaProviderTest {
 
         provider.syncProgress("session-1", item, progress, 42.0)
 
-        coVerify { localCacheRepository.syncProgress(item, progress) }
         coVerify { mediaChannel.syncProgress("session-1", progress, 42.0) }
+        coVerify { localCacheRepository.markProgressSynced("book-1") }
+        coVerify(exactly = 0) { localCacheRepository.syncProgress(any(), any()) }
       }
 
     @Test
@@ -536,6 +769,38 @@ class LissenMediaProviderTest {
         val result = provider.syncProgress("session-1", item, progress, 42.0)
 
         assertInstanceOf(OperationResult.Error::class.java, result)
+      }
+
+    @Test
+    fun `does not clear dirty when the server post fails with not found`() =
+      runBlocking {
+        val item = detailedItem("book-1")
+        val progress = PlaybackProgress(currentChapterTime = 10.0, currentTotalTime = 100.0)
+        every { preferences.isForceCache() } returns false
+        coEvery {
+          mediaChannel.syncProgress("session-1", progress, 42.0)
+        } returns OperationResult.Error(OperationError.NotFoundError)
+
+        val result = provider.syncProgress("session-1", item, progress, 42.0)
+
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        coVerify(exactly = 0) { localCacheRepository.markProgressSynced(any()) }
+      }
+  }
+
+  @Nested
+  inner class SyncProgressLocally {
+    @Test
+    fun `persists progress locally without calling the channel or clearing dirty`() =
+      runBlocking {
+        val item = detailedItem("book-1")
+        val progress = PlaybackProgress(currentChapterTime = 10.0, currentTotalTime = 100.0)
+
+        provider.syncProgressLocally(item, progress)
+
+        coVerify { localCacheRepository.syncProgress(item, progress) }
+        coVerify(exactly = 0) { mediaChannel.syncProgress(any(), any(), any()) }
+        coVerify(exactly = 0) { localCacheRepository.markProgressSynced(any()) }
       }
   }
 
@@ -668,6 +933,7 @@ class LissenMediaProviderTest {
   private fun detailedItem(
     id: String = "book-1",
     chapters: List<PlayingChapter> = emptyList(),
+    progress: MediaProgress? = null,
   ) = DetailedItem(
     id = id,
     title = "Test Book",
@@ -680,7 +946,7 @@ class LissenMediaProviderTest {
     abstract = null,
     files = emptyList(),
     chapters = chapters,
-    progress = null,
+    progress = progress,
     libraryId = "lib-1",
     localProvided = false,
     createdAt = 0L,

--- a/app/src/test/kotlin/org/grakovne/lissen/content/cache/persistent/api/CachedBookRepositoryTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/content/cache/persistent/api/CachedBookRepositoryTest.kt
@@ -569,6 +569,7 @@ class CachedBookRepositoryTest {
       assertTrue(progressSlot.captured.isFinished)
       assertEquals("b1", progressSlot.captured.bookId)
       assertEquals(60.0, progressSlot.captured.currentTime)
+      assertTrue(progressSlot.captured.dirty)
     }
 
   @Test
@@ -613,6 +614,15 @@ class CachedBookRepositoryTest {
       )
 
       assertFalse(progressSlot.captured.isFinished)
+      assertTrue(progressSlot.captured.dirty)
+    }
+
+  @Test
+  fun `markProgressSynced clears the dirty flag via the dao`() =
+    runBlocking {
+      repository.markProgressSynced("b1")
+
+      coVerify { bookDao.markMediaProgressSynced("b1") }
     }
 
   companion object {

--- a/app/src/test/kotlin/org/grakovne/lissen/content/cache/persistent/converter/MediaProgressEntityConverterTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/content/cache/persistent/converter/MediaProgressEntityConverterTest.kt
@@ -15,11 +15,19 @@ class MediaProgressEntityConverterTest {
         currentTime = 123.45,
         isFinished = true,
         lastUpdate = 9999L,
+        dirty = true,
       )
     val progress = converter.apply(entity)
     assertEquals(123.45, progress.currentTime)
     assertEquals(true, progress.isFinished)
     assertEquals(9999L, progress.lastUpdate)
+    assertEquals(true, progress.dirty)
+  }
+
+  @Test
+  fun `dirty flag is preserved when false`() {
+    val entity = MediaProgressEntity(bookId = "b", currentTime = 0.0, isFinished = false, lastUpdate = 0L)
+    assertEquals(false, converter.apply(entity).dirty)
   }
 
   @Test

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallbackTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallbackTest.kt
@@ -1,0 +1,235 @@
+package org.grakovne.lissen.playback
+
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaSession.MediaItemsWithStartPosition
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.grakovne.lissen.channel.audiobookshelf.AudiobookshelfChannelProvider
+import org.grakovne.lissen.channel.common.MediaChannel
+import org.grakovne.lissen.channel.common.OperationError
+import org.grakovne.lissen.channel.common.OperationResult
+import org.grakovne.lissen.content.LissenMediaProvider
+import org.grakovne.lissen.content.cache.persistent.LocalCacheRepository
+import org.grakovne.lissen.content.cache.temporary.CachedBookmarkProvider
+import org.grakovne.lissen.content.cache.temporary.CachedCoverProvider
+import org.grakovne.lissen.domain.BookFile
+import org.grakovne.lissen.domain.DetailedItem
+import org.grakovne.lissen.domain.MediaProgress
+import org.grakovne.lissen.domain.PlayingChapter
+import org.grakovne.lissen.persistence.preferences.LibraryPreferences
+import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
+import org.grakovne.lissen.playback.service.PlaybackSynchronizationService
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+@OptIn(UnstableApi::class)
+class MediaLibrarySessionCallbackTest {
+  private val context = mockk<Context>(relaxed = true)
+  private val playbackPreferences = mockk<PlaybackPreferences>(relaxed = true)
+  private val mediaRepository = mockk<MediaRepository>(relaxed = true)
+  private val libraryTree = mockk<MediaLibraryTree>(relaxed = true)
+  private val playbackSynchronizationService = mockk<PlaybackSynchronizationService>(relaxed = true)
+
+  private val libraryPreferences = mockk<LibraryPreferences>(relaxed = true)
+  private val channelProvider = mockk<AudiobookshelfChannelProvider>(relaxed = true)
+  private val localCacheRepository = mockk<LocalCacheRepository>(relaxed = true)
+  private val cachedCoverProvider = mockk<CachedCoverProvider>(relaxed = true)
+  private val cachedBookmarkProvider = mockk<CachedBookmarkProvider>(relaxed = true)
+  private val mediaChannel = mockk<MediaChannel>(relaxed = true)
+
+  private val mediaSession = mockk<MediaSession>(relaxed = true)
+  private val controller = mockk<MediaSession.ControllerInfo>(relaxed = true)
+
+  private val registeredBook = slot<DetailedItem>()
+
+  private lateinit var callback: MediaLibrarySessionCallback
+
+  @BeforeEach
+  fun setup() {
+    every { channelProvider.provideMediaChannel() } returns mediaChannel
+    every { libraryPreferences.isForceCache() } returns false
+    every { mediaRepository.registerPlayingBook(capture(registeredBook)) } returns Unit
+
+    // The playback queue building touches android.os.Bundle and android.net.Uri,
+    // which are stubbed in JVM unit tests.
+    mockkConstructor(Bundle::class)
+    every { anyConstructed<Bundle>().putLong(any(), any()) } returns Unit
+    every { anyConstructed<Bundle>().putParcelableArrayList(any(), any()) } returns Unit
+    mockkStatic(Uri::class)
+    every { Uri.parse(any()) } returns mockk()
+
+    val provider =
+      LissenMediaProvider(
+        libraryPreferences,
+        channelProvider,
+        localCacheRepository,
+        cachedCoverProvider,
+        cachedBookmarkProvider,
+      )
+
+    callback =
+      MediaLibrarySessionCallback(
+        context,
+        playbackPreferences,
+        mediaRepository,
+        provider,
+        libraryTree,
+        playbackSynchronizationService,
+      )
+  }
+
+  @AfterEach
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Nested
+  inner class OnPlaybackResumption {
+    @Test
+    fun `resumes at the dirty local progress when offline and the book was never downloaded`() {
+      val storedBook = bookWithChapters(progress = MediaProgress(currentTime = 0.0, isFinished = false, lastUpdate = 100))
+      val localProgress = MediaProgress(currentTime = 450.0, isFinished = false, lastUpdate = 200, dirty = true)
+
+      every { playbackPreferences.getPlayingItem() } returns storedBook
+      coEvery { mediaChannel.fetchBook(storedBook.id) } returns
+        OperationResult.Error(OperationError.NetworkError)
+      coEvery { localCacheRepository.fetchBook(storedBook.id) } returns null
+      coEvery { localCacheRepository.fetchPlayingItemProgress(storedBook.id) } returns localProgress
+
+      val result = resumptionForPlayback()
+
+      assertEquals(1, result.startIndex)
+      assertEquals(150_000L, result.startPositionMs)
+      assertEquals(localProgress, registeredBook.captured.progress)
+      verify { playbackSynchronizationService.startPlaybackSynchronization(registeredBook.captured) }
+    }
+
+    @Test
+    fun `resumes at the dirty local progress when offline and the cached copy is stale`() {
+      val storedBook = bookWithChapters(progress = MediaProgress(currentTime = 0.0, isFinished = false, lastUpdate = 100))
+      val cachedBook = bookWithChapters(progress = MediaProgress(currentTime = 10.0, isFinished = false, lastUpdate = 100))
+      val localProgress = MediaProgress(currentTime = 450.0, isFinished = false, lastUpdate = 200, dirty = true)
+
+      every { playbackPreferences.getPlayingItem() } returns storedBook
+      coEvery { mediaChannel.fetchBook(storedBook.id) } returns
+        OperationResult.Error(OperationError.NetworkError)
+      coEvery { localCacheRepository.fetchBook(storedBook.id) } returns cachedBook
+      coEvery { localCacheRepository.fetchPlayingItemProgress(storedBook.id) } returns localProgress
+
+      val result = resumptionForPlayback()
+
+      assertEquals(1, result.startIndex)
+      assertEquals(150_000L, result.startPositionMs)
+      assertEquals(localProgress, registeredBook.captured.progress)
+    }
+
+    @Test
+    fun `resumes at the dirty local progress even when the network refresh succeeds`() {
+      val storedBook = bookWithChapters(progress = MediaProgress(currentTime = 0.0, isFinished = false, lastUpdate = 100))
+      val refreshedBook = bookWithChapters(progress = MediaProgress(currentTime = 50.0, isFinished = false, lastUpdate = 999))
+      val localProgress = MediaProgress(currentTime = 450.0, isFinished = false, lastUpdate = 200, dirty = true)
+
+      every { playbackPreferences.getPlayingItem() } returns storedBook
+      coEvery { mediaChannel.fetchBook(storedBook.id) } returns OperationResult.Success(refreshedBook)
+      coEvery { localCacheRepository.fetchPlayingItemProgress(storedBook.id) } returns localProgress
+
+      val result = resumptionForPlayback()
+
+      assertEquals(1, result.startIndex)
+      assertEquals(150_000L, result.startPositionMs)
+      assertEquals(localProgress, registeredBook.captured.progress)
+    }
+
+    @Test
+    fun `resumes at the first available chapter when the dirty progress points at an uncached chapter`() {
+      // Partially downloaded book: chapter 1 is cached, chapter 2 is not.
+      val storedBook =
+        bookWithChapters(
+          progress = MediaProgress(currentTime = 0.0, isFinished = false, lastUpdate = 100),
+          chapterAvailability = listOf(true, false),
+        )
+      val localProgress = MediaProgress(currentTime = 450.0, isFinished = false, lastUpdate = 200, dirty = true)
+
+      every { playbackPreferences.getPlayingItem() } returns storedBook
+      coEvery { mediaChannel.fetchBook(storedBook.id) } returns
+        OperationResult.Error(OperationError.NetworkError)
+      coEvery { localCacheRepository.fetchBook(storedBook.id) } returns storedBook
+      coEvery { localCacheRepository.fetchPlayingItemProgress(storedBook.id) } returns localProgress
+
+      val result = resumptionForPlayback()
+
+      // The overlaid position (chapter 2, 450s) is not playable offline, so
+      // resumption must land on the first available chapter (chapter 1, 0s).
+      assertEquals(0, result.startIndex)
+      assertEquals(0L, result.startPositionMs)
+      assertEquals(0.0, registeredBook.captured.progress?.currentTime)
+      verify { playbackSynchronizationService.startPlaybackSynchronization(registeredBook.captured) }
+    }
+  }
+
+  private fun resumptionForPlayback(): MediaItemsWithStartPosition =
+    callback
+      .onPlaybackResumption(mediaSession, controller, isForPlayback = true)
+      .get(5, TimeUnit.SECONDS)
+
+  private fun bookWithChapters(
+    progress: MediaProgress,
+    chapterAvailability: List<Boolean> = listOf(true, true),
+  ): DetailedItem =
+    DetailedItem(
+      id = "book-1",
+      title = "Test Book",
+      subtitle = null,
+      author = "Author",
+      narrator = null,
+      publisher = null,
+      series = emptyList(),
+      year = null,
+      abstract = null,
+      files =
+        listOf(
+          BookFile(id = "f1", name = "part-1.mp3", duration = 300.0, size = null, mimeType = "audio/mpeg"),
+          BookFile(id = "f2", name = "part-2.mp3", duration = 300.0, size = null, mimeType = "audio/mpeg"),
+        ),
+      chapters =
+        listOf(
+          PlayingChapter(
+            available = chapterAvailability[0],
+            podcastEpisodeState = null,
+            duration = 300.0,
+            start = 0.0,
+            end = 300.0,
+            title = "Chapter 1",
+            id = "c1",
+          ),
+          PlayingChapter(
+            available = chapterAvailability[1],
+            podcastEpisodeState = null,
+            duration = 300.0,
+            start = 300.0,
+            end = 600.0,
+            title = "Chapter 2",
+            id = "c2",
+          ),
+        ),
+      progress = progress,
+      libraryId = "lib-1",
+      localProvided = false,
+      createdAt = 0L,
+      updatedAt = 0L,
+    )
+}

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/service/AdjustToFirstAvailableChapterTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/service/AdjustToFirstAvailableChapterTest.kt
@@ -1,0 +1,110 @@
+package org.grakovne.lissen.playback.service
+
+import org.grakovne.lissen.domain.DetailedItem
+import org.grakovne.lissen.domain.MediaProgress
+import org.grakovne.lissen.domain.PlayingChapter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class AdjustToFirstAvailableChapterTest {
+  private fun chapter(
+    index: Int,
+    available: Boolean,
+  ) = PlayingChapter(
+    available = available,
+    podcastEpisodeState = null,
+    duration = 300.0,
+    start = index * 300.0,
+    end = (index + 1) * 300.0,
+    title = "c$index",
+    id = "c$index",
+  )
+
+  private fun book(
+    progress: MediaProgress?,
+    vararg chapters: PlayingChapter,
+  ) = DetailedItem(
+    id = "book-1",
+    title = "Test Book",
+    subtitle = null,
+    author = null,
+    narrator = null,
+    publisher = null,
+    series = emptyList(),
+    year = null,
+    abstract = null,
+    files = emptyList(),
+    chapters = chapters.toList(),
+    progress = progress,
+    libraryId = "lib-1",
+    localProvided = false,
+    createdAt = 0L,
+    updatedAt = 0L,
+  )
+
+  @Test
+  fun `keeps the book unchanged when the current chapter is available`() {
+    val book =
+      book(
+        MediaProgress(currentTime = 450.0, isFinished = false, lastUpdate = 100),
+        chapter(0, true),
+        chapter(1, true),
+      )
+
+    val result = book.adjustToFirstAvailableChapter()
+
+    assertSame(book, result)
+  }
+
+  @Test
+  fun `adjusts to the first available chapter when the current chapter is unavailable`() {
+    val book =
+      book(
+        MediaProgress(currentTime = 450.0, isFinished = false, lastUpdate = 100),
+        chapter(0, true),
+        chapter(1, false),
+      )
+
+    val result = book.adjustToFirstAvailableChapter()
+
+    assertEquals(0.0, result?.progress?.currentTime)
+    assertEquals(946728000000L, result?.progress?.lastUpdate)
+    assertEquals(false, result?.progress?.isFinished)
+  }
+
+  @Test
+  fun `adjusts to the first available chapter when there is no progress at all`() {
+    val book =
+      book(
+        progress = null,
+        chapter(0, false),
+        chapter(1, false),
+        chapter(2, true),
+      )
+
+    val result = book.adjustToFirstAvailableChapter()
+
+    assertEquals(600.0, result?.progress?.currentTime)
+  }
+
+  @Test
+  fun `returns null when no chapter is available`() {
+    val book =
+      book(
+        MediaProgress(currentTime = 450.0, isFinished = false, lastUpdate = 100),
+        chapter(0, false),
+        chapter(1, false),
+      )
+
+    assertNull(book.adjustToFirstAvailableChapter())
+  }
+
+  @Test
+  fun `returns null for a book without chapters`() {
+    val book = book(MediaProgress(currentTime = 450.0, isFinished = false, lastUpdate = 100))
+
+    assertNull(book.adjustToFirstAvailableChapter())
+  }
+}

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/service/PlaybackSynchronizationServiceTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/service/PlaybackSynchronizationServiceTest.kt
@@ -1,0 +1,396 @@
+package org.grakovne.lissen.playback.service
+
+import android.os.Bundle
+import android.os.SystemClock
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.grakovne.lissen.channel.common.OperationError
+import org.grakovne.lissen.channel.common.OperationResult
+import org.grakovne.lissen.content.LissenMediaProvider
+import org.grakovne.lissen.domain.DetailedItem
+import org.grakovne.lissen.domain.MediaProgress
+import org.grakovne.lissen.domain.PlaybackSession
+import org.grakovne.lissen.domain.PlayingChapter
+import org.grakovne.lissen.persistence.preferences.SessionPreferences
+import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_START_MS
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.Collections
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlaybackSynchronizationServiceTest {
+  private val testDispatcher = UnconfinedTestDispatcher()
+
+  private val exoPlayer = mockk<ExoPlayer>(relaxed = true)
+  private val mediaChannel = mockk<LissenMediaProvider>(relaxed = true)
+  private val sharedPreferences = mockk<SessionPreferences>(relaxed = true)
+
+  private lateinit var service: PlaybackSynchronizationService
+  private lateinit var playerListener: Player.Listener
+
+  private var clockMs = 1_000L
+
+  @BeforeEach
+  fun setup() {
+    clearAllMocks()
+    clockMs = 1_000L
+    Dispatchers.setMain(testDispatcher)
+
+    val listenerSlot = slot<Player.Listener>()
+    every { exoPlayer.addListener(capture(listenerSlot)) } returns Unit
+
+    mockkStatic(SystemClock::class)
+    every { SystemClock.elapsedRealtime() } answers {
+      clockMs += 5_000
+      clockMs
+    }
+
+    mockkConstructor(Bundle::class)
+    every { anyConstructed<Bundle>().putLong(any(), any()) } returns Unit
+    every { anyConstructed<Bundle>().getLong(any(), any()) } returns 0L
+
+    coEvery { mediaChannel.startPlayback(any(), any(), any(), any()) } returns
+      OperationResult.Success(PlaybackSession.remote(sessionId = "session-id", itemId = "book-id"))
+    coEvery { mediaChannel.syncProgress(any(), any(), any(), any()) } returns OperationResult.Success(Unit)
+
+    service = PlaybackSynchronizationService(exoPlayer, mediaChannel, sharedPreferences)
+    playerListener = listenerSlot.captured
+  }
+
+  @AfterEach
+  fun tearDown() {
+    unmockkAll()
+    Dispatchers.resetMain()
+  }
+
+  private fun playerAt(
+    positionMs: Long,
+    isPlaying: Boolean = false,
+    playWhenReady: Boolean = false,
+  ) {
+    val extras = Bundle().apply { putLong(CHAPTER_START_MS, 0L) }
+    val metadata = MediaMetadata.Builder().setExtras(extras).build()
+    val mediaItem = MediaItem.Builder().setMediaMetadata(metadata).build()
+
+    every { exoPlayer.currentMediaItem } returns mediaItem
+    every { exoPlayer.currentPosition } returns positionMs
+    every { exoPlayer.isPlaying } returns isPlaying
+    every { exoPlayer.playWhenReady } returns playWhenReady
+  }
+
+  private fun bookWithProgress(currentTime: Double): DetailedItem =
+    DetailedItem(
+      id = "book-id",
+      title = "title",
+      subtitle = null,
+      author = null,
+      narrator = null,
+      publisher = null,
+      series = emptyList(),
+      year = null,
+      abstract = null,
+      files = emptyList(),
+      chapters =
+        listOf(
+          PlayingChapter(
+            available = true,
+            podcastEpisodeState = null,
+            duration = 300.0,
+            start = 0.0,
+            end = 300.0,
+            title = "chapter-0",
+            id = "chapter-0",
+          ),
+        ),
+      progress = MediaProgress(currentTime = currentTime, isFinished = false, lastUpdate = 0),
+      libraryId = "library-id",
+      localProvided = false,
+      createdAt = 0,
+      updatedAt = 0,
+    )
+
+  /**
+   * Builds an events object that reports exactly the given events, so the
+   * tests exercise which [Player.Events] actually trigger a sync instead of
+   * stubbing `contains` to always return true.
+   */
+  private fun playbackEvents(vararg events: Int) =
+    mockk<Player.Events> {
+      every { contains(any()) } answers { firstArg<Int>() in events }
+    }
+
+  @Nested
+  inner class RestoredPositionSync {
+    @Test
+    fun `opening a book and doing nothing does not sync the restored position`() =
+      runTest(testDispatcher) {
+        playerAt(positionMs = 100_000L)
+        service.startPlaybackSynchronization(bookWithProgress(100.0))
+        playerListener.onEvents(exoPlayer, playbackEvents(Player.EVENT_MEDIA_ITEM_TRANSITION))
+
+        coVerify(exactly = 0) { mediaChannel.syncProgress(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { mediaChannel.startPlayback(any(), any(), any(), any()) }
+      }
+
+    @Test
+    fun `pressing play produces a sync even when the position has not moved`() =
+      runTest(testDispatcher) {
+        playerAt(positionMs = 100_000L)
+        service.startPlaybackSynchronization(bookWithProgress(100.0))
+        playerListener.onEvents(exoPlayer, playbackEvents(Player.EVENT_MEDIA_ITEM_TRANSITION))
+        coVerify(exactly = 0) { mediaChannel.syncProgress(any(), any(), any(), any()) }
+
+        playerAt(positionMs = 100_000L, isPlaying = true, playWhenReady = true)
+        playerListener.onEvents(exoPlayer, playbackEvents(Player.EVENT_IS_PLAYING_CHANGED))
+
+        testScheduler.advanceTimeBy(SYNC_INTERVAL_SHORT.milliseconds)
+        runCurrent()
+
+        coVerify(timeout = 5_000) {
+          mediaChannel.syncProgress(
+            sessionId = "session-id",
+            detailedItem = any(),
+            progress = match { it.currentTotalTime == 100.0 },
+            timeListened = 5.0,
+          )
+        }
+
+        service.cancelSynchronization()
+      }
+
+    @Test
+    fun `seeking without playing produces a sync`() =
+      runTest(testDispatcher) {
+        playerAt(positionMs = 100_000L)
+        service.startPlaybackSynchronization(bookWithProgress(100.0))
+        playerListener.onEvents(exoPlayer, playbackEvents(Player.EVENT_MEDIA_ITEM_TRANSITION))
+        coVerify(exactly = 0) { mediaChannel.syncProgress(any(), any(), any(), any()) }
+
+        // A seek inside the buffered region emits only
+        // EVENT_POSITION_DISCONTINUITY; while paused no periodic loop is
+        // running, so this event alone must trigger the sync.
+        playerAt(positionMs = 150_000L)
+        playerListener.onEvents(exoPlayer, playbackEvents(Player.EVENT_POSITION_DISCONTINUITY))
+
+        coVerify(timeout = 5_000) {
+          mediaChannel.syncProgress(
+            sessionId = "session-id",
+            detailedItem = any(),
+            progress = match { it.currentTotalTime == 150.0 },
+            timeListened = 0.0,
+          )
+        }
+      }
+
+    @Test
+    fun `after listening and a successful sync, a pause at the restored start position still syncs`() =
+      runTest(testDispatcher) {
+        playerAt(positionMs = 100_000L)
+        service.startPlaybackSynchronization(bookWithProgress(100.0))
+        playerListener.onEvents(exoPlayer, playbackEvents(Player.EVENT_MEDIA_ITEM_TRANSITION))
+        coVerify(exactly = 0) { mediaChannel.syncProgress(any(), any(), any(), any()) }
+
+        // Listening: playing accumulates listening time, releases the restore
+        // gate, and a successful sync brings unsyncedMs back to exactly 0.
+        playerAt(positionMs = 100_000L, isPlaying = true, playWhenReady = true)
+        playerListener.onEvents(exoPlayer, playbackEvents(Player.EVENT_IS_PLAYING_CHANGED))
+
+        testScheduler.advanceTimeBy(SYNC_INTERVAL_SHORT.milliseconds)
+        runCurrent()
+
+        coVerify(timeout = 5_000) {
+          mediaChannel.syncProgress(
+            sessionId = "session-id",
+            detailedItem = any(),
+            progress = match { it.currentTotalTime == 100.0 },
+            timeListened = 5.0,
+          )
+        }
+        runCurrent()
+
+        // The user is now paused at the restored start position. The first pause
+        // event syncs the last listening stretch (unsyncedMs back to 0); a
+        // subsequent sync event while paused there must not be suppressed by the
+        // restore gate.
+        playerAt(positionMs = 100_000L)
+        playerListener.onEvents(exoPlayer, playbackEvents(Player.EVENT_IS_PLAYING_CHANGED))
+
+        playerAt(positionMs = 100_000L)
+        playerListener.onEvents(exoPlayer, playbackEvents(Player.EVENT_IS_PLAYING_CHANGED))
+
+        coVerify(timeout = 5_000) {
+          mediaChannel.syncProgress(
+            sessionId = "session-id",
+            detailedItem = any(),
+            progress = match { it.currentTotalTime == 100.0 },
+            timeListened = 0.0,
+          )
+        }
+
+        service.cancelSynchronization()
+      }
+  }
+
+  @Nested
+  inner class SyncWritePath {
+    @Test
+    fun `local write happens before the session opens and the server post`() =
+      runTest(testDispatcher) {
+        playerAt(positionMs = 100_000L, isPlaying = true, playWhenReady = true)
+        service.startPlaybackSynchronization(bookWithProgress(100.0))
+        playerListener.onEvents(exoPlayer, playbackEvents(Player.EVENT_IS_PLAYING_CHANGED))
+
+        testScheduler.advanceTimeBy(SYNC_INTERVAL_SHORT.milliseconds)
+        runCurrent()
+
+        coVerify(timeout = 5_000) {
+          mediaChannel.syncProgress(any(), any(), any(), any())
+        }
+        coVerifyOrder {
+          mediaChannel.syncProgressLocally(any(), any())
+          mediaChannel.startPlayback(any(), any(), any(), any())
+          mediaChannel.syncProgress(any(), any(), any(), any())
+        }
+
+        service.cancelSynchronization()
+      }
+
+    @Test
+    fun `local write happens before the server post on every sync even when the session is already open`() =
+      runTest(testDispatcher) {
+        val callOrder = recordSyncCalls()
+
+        playerAt(positionMs = 100_000L, isPlaying = true, playWhenReady = true)
+        service.startPlaybackSynchronization(bookWithProgress(100.0))
+        playerListener.onEvents(exoPlayer, playbackEvents(Player.EVENT_IS_PLAYING_CHANGED))
+
+        // The session is already open for the second sync, so no session
+        // reopen happens, but the local write still precedes the post.
+        awaitSyncSequence(testScheduler, callOrder, listOf("local", "session", "post", "local", "post"))
+
+        service.cancelSynchronization()
+      }
+
+    @Test
+    fun `local write happens even when the playback session cannot be opened`() =
+      runTest(testDispatcher) {
+        val callOrder = recordSyncCalls()
+        coEvery { mediaChannel.startPlayback(any(), any(), any(), any()) } returns
+          OperationResult.Error(OperationError.NetworkError)
+
+        playerAt(positionMs = 100_000L, isPlaying = true, playWhenReady = true)
+        service.startPlaybackSynchronization(bookWithProgress(100.0))
+        playerListener.onEvents(exoPlayer, playbackEvents(Player.EVENT_IS_PLAYING_CHANGED))
+
+        testScheduler.advanceTimeBy(SYNC_INTERVAL_SHORT.milliseconds)
+        runCurrent()
+
+        awaitCallOrder(callOrder, listOf("local"))
+        assertEquals(listOf("local"), callOrder)
+        coVerify(exactly = 0) { mediaChannel.syncProgress(any(), any(), any(), any()) }
+
+        service.cancelSynchronization()
+      }
+
+    private fun recordSyncCalls(): MutableList<String> {
+      val callOrder = Collections.synchronizedList(mutableListOf<String>())
+      coEvery { mediaChannel.syncProgressLocally(any(), any()) } answers {
+        callOrder.add("local")
+        Unit
+      }
+      coEvery { mediaChannel.startPlayback(any(), any(), any(), any()) } answers {
+        callOrder.add("session")
+        OperationResult.Success(PlaybackSession.remote(sessionId = "session-id", itemId = "book-id"))
+      }
+      coEvery { mediaChannel.syncProgress(any(), any(), any(), any()) } answers {
+        callOrder.add("post")
+        OperationResult.Success(Unit)
+      }
+      return callOrder
+    }
+
+    private fun awaitCallOrder(
+      callOrder: List<String>,
+      expected: List<String>,
+    ) {
+      val deadline = System.currentTimeMillis() + 5_000
+      while (callOrder != expected && System.currentTimeMillis() < deadline) {
+        Thread.sleep(10)
+      }
+    }
+
+    /**
+     * Advances virtual time until [expected] shows up in [callOrder]. Each
+     * interval tick fires the periodic sync loop, and the real-time polling
+     * lets the in-flight sync (which runs on the IO dispatcher) finish before
+     * the next tick.
+     */
+    private fun awaitSyncSequence(
+      scheduler: TestCoroutineScheduler,
+      callOrder: List<String>,
+      expected: List<String>,
+    ) {
+      val deadline = System.currentTimeMillis() + 5_000
+      while (callOrder.size < expected.size && System.currentTimeMillis() < deadline) {
+        scheduler.advanceTimeBy(SYNC_INTERVAL_SHORT.milliseconds)
+        scheduler.runCurrent()
+        Thread.sleep(20)
+      }
+      assertEquals(expected, callOrder)
+    }
+  }
+
+  @Nested
+  inner class RestoredPositionUnchanged {
+    @Test
+    fun `position equal to the restored start with no listening time is unchanged`() {
+      assertTrue(isRestoredPositionUnchanged(restoredStartPosition = 100.0, currentPosition = 100.0, unsyncedMs = 0))
+    }
+
+    @Test
+    fun `position within tolerance of the restored start is unchanged`() {
+      assertTrue(isRestoredPositionUnchanged(restoredStartPosition = 100.0, currentPosition = 100.05, unsyncedMs = 0))
+    }
+
+    @Test
+    fun `position beyond tolerance releases the gate`() {
+      assertFalse(isRestoredPositionUnchanged(restoredStartPosition = 100.0, currentPosition = 100.2, unsyncedMs = 0))
+    }
+
+    @Test
+    fun `accumulated listening time releases the gate even at the restored position`() {
+      assertFalse(isRestoredPositionUnchanged(restoredStartPosition = 100.0, currentPosition = 100.0, unsyncedMs = 5_000))
+    }
+
+    @Test
+    fun `missing restored start position keeps the gate open`() {
+      assertFalse(isRestoredPositionUnchanged(restoredStartPosition = null, currentPosition = 100.0, unsyncedMs = 0))
+    }
+  }
+}


### PR DESCRIPTION
Listening to a book offline and then having the process killed lost the whole
session: on reopening, the position was back where it had been an hour earlier,
and the server had the old value too.

### Cause

Opening or resuming a book calls `prepare()`, which fires
`EVENT_PLAYBACK_STATE_CHANGED` and makes `runSync` sync straight away. The only
guard was a zero position.

Offline, `refreshBookForResumption` hits its two second timeout and falls back to
the stored playing item, whose progress is frozen at the moment the book was
first opened, because `savePlayingItem` is never called as playback advances. So
the player seeked to the hour-old position, and that position was then written to
both the local database and the server, destroying the good progress.

The correct position was sitting in the `media_progress` row the whole time.
Nothing on the offline restore path read it: `mergeLocalItemProgress` was only
applied on `fetchBook`'s network-success branch, and the failure branch falls
back to `LocalCacheRepository.fetchBook`, which returns null for any book that
was never downloaded.

### Changes

**A `dirty` flag on `media_progress`** (migration 21 → 22). Set on every local
write, cleared only when a server POST actually succeeds. A dirty row means the
server does not have this value, so it wins outright on restore.

This is deliberately not a pure `lastUpdate` comparison. The existing comparison
puts a device clock timestamp against a server clock one, so clock skew can lose
progress in exactly the way described above. The non-dirty path still compares
timestamps, which is fine because there both sides agree.

**A one-shot gate on outbound syncs.** `runSync` skips while no listening time
has accumulated and the position still equals the one the item was restored to.
Playing or seeking releases it, once per item. Backwards seeks still sync.

`EVENT_POSITION_DISCONTINUITY` is now observed too: a seek inside the buffered
region need not emit any of the three events already watched, and there is no
periodic loop while paused, so such a seek could go unsynced. That predates this
change but matters more now that the gate needs a sync to release.

**Local write moved ahead of the network** in `performSync`. It used to sit
behind `openPlaybackSession`, and with no OkHttp timeouts configured that left a
ten second window where a process kill lost the write.

**Two clobber guards.** `upsertCachedBook` no longer replaces a dirty row, and
the restore paths in `fetchBook` and `onPlaybackResumption` read the local row,
including for books that were never downloaded.

**A shared first-available-chapter adjustment.** `LocalCacheRepository.fetchBook`
already adjusted a position pointing at an uncached chapter; the new overlay ran
after it and discarded it. A partially downloaded book with a dirty row in an
uncached chapter would then reach for the remote URI while offline and fail to
start instead of beginning at the first cached chapter. Both paths now share the
adjustment.

### Not covered

Offline listening time is still lost if the process dies before reconnecting.
`unsyncedMs` only shrinks on a successful POST, so positions come back correct
but server listening statistics do not. Replaying that needs an outbound queue,
which this does not add. The `dirty` flag is a reasonable foundation for it.

Two smaller known flaws left alone: `startPlaybackSynchronization` resets
`playingSince` but not `unsyncedMs`, so leftover listening time is reported
against the next book; and `performSync` reopens the session on every sync while
`sessionSource` is `LOCAL`, which burns a network timeout per cycle offline.
Wasteful rather than incorrect now that the local write happens first.

### Tests

Unit tests for the sync gate (open and do nothing, play, seek while paused,
position discontinuity only), the dirty invariant across the offline-mode and
404 cases, the write ordering, the dirty-wins read path, and the chapter
adjustment. Instrumented tests for the migration and the DAO guard. The
regression tests for the chapter adjustment were checked to fail when the fix is
reverted.

`./gradlew build -Proom.schemaLocation=$PWD/app/schemas` passes.
