### PR TITLE
Centralize chapter queue creation

### DIFF
--- a/app/src/androidTest/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallbackTest.kt
+++ b/app/src/androidTest/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallbackTest.kt
@@ -203,6 +203,28 @@ class MediaLibrarySessionCallbackTest {
     }
 
   @Test
+  fun onSetMediaItems_andPlaybackResumption_resolveTheSameChapterQueue() =
+    runBlocking {
+      val book = makeDetailedItem("book-1", "My Book", MediaProgress(170.0, false, 0L))
+      every { preferences.getPlayingItem() } returns book
+      coEvery { lissenMediaProvider.fetchBook("book-1") } returns OperationResult.Success(book)
+
+      val mediaItem = MediaItem.Builder().setMediaId(MediaLibraryTree.bookPath("book-1")).build()
+      val setItemsResult =
+        callback
+          .onSetMediaItems(session, controller, listOf(mediaItem), C.INDEX_UNSET, C.TIME_UNSET)
+          .get(5, TimeUnit.SECONDS)
+      val resumptionResult =
+        callback
+          .onPlaybackResumption(session, controller, isForPlayback = false)
+          .get(5, TimeUnit.SECONDS)
+
+      assertEquals(setItemsResult.mediaItems.map { it.mediaId }, resumptionResult.mediaItems.map { it.mediaId })
+      assertEquals(setItemsResult.startIndex, resumptionResult.startIndex)
+      assertEquals(setItemsResult.startPositionMs, resumptionResult.startPositionMs)
+    }
+
+  @Test
   fun onPlaybackResumption_storedBook_refreshesAndResolvesQueue() =
     runBlocking {
       val storedBook = makeDetailedItem("book-1", "Stored Book", MediaProgress(170.0, false, 0L))

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/MediaLibrarySessionCallback.kt
@@ -33,8 +33,8 @@ import org.grakovne.lissen.channel.common.OperationResult
 import org.grakovne.lissen.content.LissenMediaProvider
 import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.persistence.preferences.PlaybackPreferences
-import org.grakovne.lissen.playback.service.PlaybackService
 import org.grakovne.lissen.playback.service.PlaybackSynchronizationService
+import org.grakovne.lissen.playback.service.bookToChapterMediaItems
 import org.grakovne.lissen.util.listenableFuture
 import timber.log.Timber
 import javax.inject.Inject
@@ -238,7 +238,7 @@ class MediaLibrarySessionCallback
                     preferences.savePlayingItem(it)
                     playbackSynchronizationService.startPlaybackSynchronization(it)
                     mediaRepository.registerPlayingBook(it)
-                    PlaybackService.bookToChapterMediaItems(it)
+                    bookToChapterMediaItems(it)
                   },
                   onFailure = { MediaItemsWithStartPosition(emptyList(), 0, 0) },
                 )
@@ -274,7 +274,7 @@ class MediaLibrarySessionCallback
             mediaRepository.registerPlayingBook(book)
           }
 
-          PlaybackService.bookToChapterMediaItems(book)
+          bookToChapterMediaItems(book)
         }
 
     private suspend fun refreshBookForResumption(storedBook: DetailedItem): DetailedItem? {

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/ChapterQueue.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/ChapterQueue.kt
@@ -1,0 +1,60 @@
+package org.grakovne.lissen.playback.service
+
+import android.os.Bundle
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaSession.MediaItemsWithStartPosition
+import org.grakovne.lissen.content.ExternalCoverProvider
+import org.grakovne.lissen.domain.DetailedItem
+import org.grakovne.lissen.playback.service.PlaybackService.Companion.CHAPTER_START_MS
+import org.grakovne.lissen.playback.service.PlaybackService.Companion.FILE_SEGMENTS
+
+@UnstableApi
+fun bookToChapterMediaItems(book: DetailedItem): MediaItemsWithStartPosition {
+  var (chapterIndex, chapterOffset) =
+    book
+      .progress
+      ?.currentTime
+      ?.let { calculateChapterIndexAndPosition(book, it) }
+      ?: ChapterPosition(0, 0.0)
+
+  val negativeChapter = chapterIndex < 0
+  val lastMoments =
+    !negativeChapter &&
+      book.chapters.isNotEmpty() &&
+      (book.chapters.last().end - 5) < (book.progress?.currentTime ?: 0.0)
+
+  if (negativeChapter || lastMoments) {
+    chapterIndex = 0
+    chapterOffset = 0.0
+  }
+
+  val chapterMediaItems =
+    PlaybackService.resolveChapterToFiles(chapters = book.chapters, files = book.files) { index, chapter, resolvedFiles ->
+      MediaItem
+        .Builder()
+        .setMediaId(LissenMediaSourceFactory.MediaId(book.id, index).toString())
+        .setRequestMetadata(
+          MediaItem.RequestMetadata
+            .Builder()
+            .setExtras(Bundle().apply { putParcelableArrayList(FILE_SEGMENTS, resolvedFiles) })
+            .build(),
+        ).setMediaMetadata(
+          MediaMetadata
+            .Builder()
+            .setAlbumTitle(book.title)
+            .setTitle(chapter.title)
+            .setArtist(book.title)
+            .setIsBrowsable(false)
+            .setIsPlayable(true)
+            .setArtworkUri(ExternalCoverProvider.bookCoverUri(book.id))
+            .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK_CHAPTER)
+            .setExtras(Bundle().apply { putLong(CHAPTER_START_MS, (chapter.start * 1000).toLong()) })
+            .build(),
+        ).setTag(book)
+        .build()
+    }
+
+  return MediaItemsWithStartPosition(chapterMediaItems, chapterIndex, (chapterOffset * 1000).toLong())
+}

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackService.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackService.kt
@@ -1,16 +1,12 @@
 package org.grakovne.lissen.playback.service
 
 import android.content.Intent
-import android.os.Bundle
 import androidx.annotation.OptIn
-import androidx.media3.common.MediaItem
-import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
-import androidx.media3.session.MediaSession.MediaItemsWithStartPosition
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
@@ -19,7 +15,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.grakovne.lissen.content.ExternalCoverProvider
 import org.grakovne.lissen.domain.BookFile
 import org.grakovne.lissen.domain.DetailedItem
 import org.grakovne.lissen.domain.PlayingChapter
@@ -219,52 +214,9 @@ class PlaybackService : MediaLibraryService() {
     }
 
     @UnstableApi
-    fun bookToChapterMediaItems(book: DetailedItem): MediaItemsWithStartPosition {
-      var (chapterIndex, chapterOffset) =
-        book
-          .progress
-          ?.currentTime
-          ?.let { calculateChapterIndexAndPosition(book, it) }
-          ?: ChapterPosition(0, 0.0)
-
-      val negativeChapter = chapterIndex < 0
-      val lastMoments =
-        !negativeChapter &&
-          book.chapters.isNotEmpty() &&
-          (book.chapters.last().end - 5) < (book.progress?.currentTime ?: 0.0)
-
-      if (negativeChapter || lastMoments) {
-        chapterIndex = 0
-        chapterOffset = 0.0
-      }
-
-      val chapterMediaItems =
-        resolveChapterToFiles(chapters = book.chapters, files = book.files) { index, chapter, resolvedFiles ->
-          MediaItem
-            .Builder()
-            .setMediaId(LissenMediaSourceFactory.MediaId(book.id, index).toString())
-            .setRequestMetadata(
-              MediaItem.RequestMetadata
-                .Builder()
-                .setExtras(Bundle().apply { putParcelableArrayList(FILE_SEGMENTS, resolvedFiles) })
-                .build(),
-            ).setMediaMetadata(
-              MediaMetadata
-                .Builder()
-                .setAlbumTitle(book.title)
-                .setTitle(chapter.title)
-                .setArtist(book.title)
-                .setIsBrowsable(false)
-                .setIsPlayable(true)
-                .setArtworkUri(ExternalCoverProvider.bookCoverUri(book.id))
-                .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK_CHAPTER)
-                .setExtras(Bundle().apply { putLong(CHAPTER_START_MS, (chapter.start * 1000).toLong()) })
-                .build(),
-            ).setTag(book)
-            .build()
-        }
-      return MediaItemsWithStartPosition(chapterMediaItems, chapterIndex, (chapterOffset * 1000).toLong())
-    }
+    fun bookToChapterMediaItems(book: DetailedItem) =
+      org.grakovne.lissen.playback.service
+        .bookToChapterMediaItems(book)
   }
 }
 

--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackService.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/PlaybackService.kt
@@ -212,11 +212,6 @@ class PlaybackService : MediaLibraryService() {
 
       return result
     }
-
-    @UnstableApi
-    fun bookToChapterMediaItems(book: DetailedItem) =
-      org.grakovne.lissen.playback.service
-        .bookToChapterMediaItems(book)
   }
 }
 


### PR DESCRIPTION
This PR centralizes the existing chapter queue construction without changing playback behavior. PlaybackService, MediaSession item resolution, and playback resumption now use the same code path.
This refactoring is intentionally separate from track playback. Keeping the first PR behavior-neutral makes it easier to verify that queue construction has not regressed and gives the later feature work one well-tested integration point.

This PR is part of a series of PRs targeting the implementation of having two modes of playback, chapters and tracks.

All the following 6 PRs contribute to this goal, but for the sake of clarity and easier readability, are divided in to multiple parts.