### PR TITLE
fix: keep syncing progress to server in "Downloaded only" mode

### DIFF
--- a/app/src/main/kotlin/org/grakovne/lissen/content/LissenMediaProvider.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/content/LissenMediaProvider.kt
@@ -106,8 +106,6 @@ class LissenMediaProvider
 
       localCacheRepository.syncProgress(detailedItem, progress)
 
-      if (preferences.isForceCache()) return OperationResult.Success(Unit)
-
       return providePreferredChannel()
         .syncProgress(sessionId, progress, timeListened)
     }
@@ -281,8 +279,6 @@ class LissenMediaProvider
       deviceId: String,
     ): OperationResult<PlaybackSession> {
       Timber.d("Starting playback: itemId=$itemId, chapterId=$chapterId, mimeTypes=$supportedMimeTypes")
-
-      if (preferences.isForceCache()) return OperationResult.Success(PlaybackSession.local(itemId))
 
       return providePreferredChannel()
         .startPlayback(

--- a/app/src/test/kotlin/org/grakovne/lissen/content/LissenMediaProviderTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/content/LissenMediaProviderTest.kt
@@ -444,9 +444,29 @@ class LissenMediaProviderTest {
   @Nested
   inner class StartPlayback {
     @Test
-    fun `returns local session without calling channel when force cache enabled`() =
+    fun `opens remote session via channel even when force cache enabled`() =
+      runBlocking {
+        val session = PlaybackSession.remote("session-1", "book-1")
+        every { preferences.isForceCache() } returns true
+        coEvery {
+          mediaChannel.startPlayback(any(), any(), any(), any())
+        } returns OperationResult.Success(session)
+
+        val result = provider.startPlayback("book-1", "ep-1", listOf("audio/mp3"), "device-1")
+
+        assertInstanceOf(OperationResult.Success::class.java, result)
+        assertEquals(PlaybackSessionSource.REMOTE, (result as OperationResult.Success).data.sessionSource)
+        assertEquals("session-1", result.data.sessionId)
+        coVerify(exactly = 1) { mediaChannel.startPlayback("book-1", "ep-1", any(), any()) }
+      }
+
+    @Test
+    fun `falls back to local session on channel failure when force cache enabled`() =
       runBlocking {
         every { preferences.isForceCache() } returns true
+        coEvery {
+          mediaChannel.startPlayback(any(), any(), any(), any())
+        } returns OperationResult.Error(OperationError.NetworkError)
 
         val result = provider.startPlayback("book-1", "ep-1", listOf("audio/mp3"), "device-1")
 
@@ -454,7 +474,6 @@ class LissenMediaProviderTest {
         val session = (result as OperationResult.Success).data
         assertEquals("book-1", session.itemId)
         assertEquals(PlaybackSessionSource.LOCAL, session.sessionSource)
-        coVerify(exactly = 0) { mediaChannel.startPlayback(any(), any(), any(), any()) }
       }
 
     @Test
@@ -495,17 +514,35 @@ class LissenMediaProviderTest {
   @Nested
   inner class SyncProgress {
     @Test
-    fun `syncs local cache without calling channel when force cache enabled`() =
+    fun `syncs local cache and channel when force cache enabled`() =
       runBlocking {
         val item = detailedItem("book-1")
         val progress = PlaybackProgress(currentChapterTime = 10.0, currentTotalTime = 100.0)
         every { preferences.isForceCache() } returns true
+        coEvery { mediaChannel.syncProgress("session-1", progress, 42.0) } returns
+          OperationResult.Success(Unit)
 
         val result = provider.syncProgress("session-1", item, progress, 42.0)
 
         assertInstanceOf(OperationResult.Success::class.java, result)
         coVerify { localCacheRepository.syncProgress(item, progress) }
-        coVerify(exactly = 0) { mediaChannel.syncProgress(any(), any(), any()) }
+        coVerify(exactly = 1) { mediaChannel.syncProgress("session-1", progress, 42.0) }
+      }
+
+    @Test
+    fun `keeps local progress and reports channel failure when force cache enabled`() =
+      runBlocking {
+        val item = detailedItem("book-1")
+        val progress = PlaybackProgress(currentChapterTime = 10.0, currentTotalTime = 100.0)
+        every { preferences.isForceCache() } returns true
+        coEvery { mediaChannel.syncProgress("session-1", progress, 42.0) } returns
+          OperationResult.Error(OperationError.NetworkError)
+
+        val result = provider.syncProgress("session-1", item, progress, 42.0)
+
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertEquals(OperationError.NetworkError, (result as OperationResult.Error).code)
+        coVerify { localCacheRepository.syncProgress(item, progress) }
       }
 
     @Test
@@ -536,6 +573,7 @@ class LissenMediaProviderTest {
         val result = provider.syncProgress("session-1", item, progress, 42.0)
 
         assertInstanceOf(OperationResult.Error::class.java, result)
+        assertEquals(OperationError.NetworkError, (result as OperationResult.Error).code)
       }
   }
 


### PR DESCRIPTION
"Downloaded only" is a library filter, but since #474 it also acted as an offline mode: syncProgress() and startPlayback() returned early without touching the server, so progress never reached Audiobookshelf until the toggle was switched off (#502).

The early returns are not needed for offline playback: sync runs in a background coroutine via CoalescingRunner and never blocks the player, startPlayback() already falls back to a local session on failure, and PlaybackSynchronizationService retries opening a remote session on the next tick while the session is local. Remove them so progress syncs whenever the server is reachable, regardless of the filter.

Side effect: syncProgress() now reports the real channel result, so unsynced listening time is no longer discarded on failed syncs.

Also make the pre-existing "uses channel result when force cache disabled" test return Unit; it ended with assertInstanceOf, which made the function non-void and JUnit 5 silently skipped it.

Fixes #502
