### PR TITLE
fix: make podcast episode sorting thread-safe

### DIFF
--- a/app/src/main/kotlin/org/grakovne/lissen/channel/audiobookshelf/podcast/converter/PodcastResponseConverter.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/channel/audiobookshelf/podcast/converter/PodcastResponseConverter.kt
@@ -111,20 +111,32 @@ class PodcastResponseConverter
 
     companion object {
       private const val FINISHED_PROGRESS_THRESHOLD = 0.9
-      private val dateFormat = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH)
+      private const val PUB_DATE_PATTERN = "EEE, dd MMM yyyy HH:mm:ss Z"
 
-      private fun List<PodcastEpisodeResponse>.orderEpisode() =
-        this.sortedWith(
-          compareBy<PodcastEpisodeResponse> { item ->
+      private data class EpisodeOrder(
+        val publishedAt: Long?,
+        val season: Int?,
+        val episode: Int?,
+      )
+
+      // SimpleDateFormat is not thread-safe and podcast books are fetched concurrently,
+      // so parsing happens once per sort with a dedicated instance instead of a shared one.
+      private fun List<PodcastEpisodeResponse>.orderEpisode(): List<PodcastEpisodeResponse> {
+        val dateFormat = SimpleDateFormat(PUB_DATE_PATTERN, Locale.ENGLISH)
+
+        return map { item ->
+          val publishedAt =
             try {
               item.pubDate?.let { dateFormat.parse(it)?.time }
             } catch (e: Exception) {
               Timber.w("Unable to parse episode pubDate '${item.pubDate}' due to: ${e.message}")
               null
             }
-          }.thenBy { it.season.safeToInt() }
-            .thenBy { it.episode.safeToInt() },
-        )
+          EpisodeOrder(publishedAt, item.season.safeToInt(), item.episode.safeToInt()) to item
+        }.sortedWith(
+          compareBy({ it.first.publishedAt }, { it.first.season }, { it.first.episode }),
+        ).map { it.second }
+      }
 
       private fun String?.safeToInt(): Int? {
         val maybeNumber = this?.takeIf { it.isNotBlank() }

--- a/app/src/test/kotlin/org/grakovne/lissen/channel/audiobookshelf/podcast/converter/PodcastResponseConverterTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/channel/audiobookshelf/podcast/converter/PodcastResponseConverterTest.kt
@@ -12,6 +12,7 @@ import org.grakovne.lissen.domain.LibraryType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import java.util.concurrent.Executors
 
 class PodcastResponseConverterTest {
   private val converter = PodcastResponseConverter()
@@ -106,6 +107,32 @@ class PodcastResponseConverterTest {
     val result = converter.apply(podcast(episodes))
 
     assertEquals(listOf("bad", "good"), result.files.map { it.id })
+  }
+
+  @Test
+  fun `orders episodes consistently when many threads convert at once`() {
+    val episodes =
+      (1..50).map { index ->
+        episode(
+          id = "e$index",
+          pubDate = "Sun, %02d Feb 2024 %02d:00:00 +0000".format(index % 28 + 1, index % 24),
+          season = (index % 4).toString(),
+          episode = (index % 6).toString(),
+        )
+      }
+    val expected = converter.apply(podcast(episodes)).files.map { it.id }
+
+    val executor = Executors.newFixedThreadPool(8)
+    try {
+      val results =
+        (1..100)
+          .map { executor.submit<List<String>> { converter.apply(podcast(episodes)).files.map { file -> file.id } } }
+          .map { future -> future.get() }
+
+      results.forEach { assertEquals(expected, it) }
+    } finally {
+      executor.shutdown()
+    }
   }
 
   @Test


### PR DESCRIPTION
Fixes Acrarium [#2014](https://acrarium.grakovne.org/app/1/bug/2014) (TimSort \"Comparison method violates its general contract!\" while converting podcast responses).

**Root cause:** a shared static \"SimpleDateFormat\" was parsed concurrently from multiple coroutines, returning corrupted dates and breaking the comparator contract during episode sorting.

**Fix:** \"orderEpisode\" now uses a single local formatter and precomputes an \"EpisodeOrder\" key per episode, so each sort compares stable values.

**Tests:** added a concurrency test (100 tasks x 8 threads) that fails on the old code and passes on the new one; full unit suite is green.