### PR TITLE
fix: sanitize corrupted clip bounds before building media sources

### DIFF
--- a/app/src/main/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactory.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactory.kt
@@ -2,6 +2,7 @@ package org.grakovne.lissen.playback.service
 
 import android.os.Parcelable
 import androidx.core.os.BundleCompat
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.util.UnstableApi
@@ -63,21 +64,33 @@ class LissenMediaSourceFactory(
     fun FileClip.toMediaSource(
       bookId: String,
       metadata: MediaMetadata? = null,
-    ): MediaSource =
-      mediaSourceFactory
-        .createMediaSource(
-          MediaItem
-            .Builder()
-            .setUri(toLissenUri(bookId, fileId))
-            .apply { metadata?.let { setMediaMetadata(it) } }
-            .build(),
-        ).let {
+    ): MediaSource {
+      val source =
+        mediaSourceFactory
+          .createMediaSource(
+            MediaItem
+              .Builder()
+              .setUri(toLissenUri(bookId, fileId))
+              .apply { metadata?.let { setMediaMetadata(it) } }
+              .build(),
+          )
+
+      val (startUs, endUs) = clipBoundsUs(clipStart, clipEnd)
+
+      return when {
+        startUs == 0L && endUs == C.TIME_UNSET -> {
+          source
+        }
+
+        else -> {
           ClippingMediaSource
-            .Builder(it)
-            .setStartPositionUs((clipStart * 1_000_000).toLong())
-            .setEndPositionUs((clipEnd * 1_000_000).toLong())
+            .Builder(source)
+            .setStartPositionUs(startUs)
+            .setEndPositionUs(endUs)
             .build()
         }
+      }
+    }
 
     return MediaId.fromString(mediaItem.mediaId)?.let { (bookId, chapterId) ->
       mediaItem.requestMetadata.extras?.let { extras ->
@@ -96,7 +109,7 @@ class LissenMediaSourceFactory(
                 .Builder()
                 .apply {
                   segments.forEach {
-                    add(it.toMediaSource(bookId), ((it.clipEnd - it.clipStart) * 1000).toLong())
+                    add(it.toMediaSource(bookId), segmentDurationMs(it.clipStart, it.clipEnd))
                   }
                 }.setMediaItem(
                   MediaItem
@@ -109,5 +122,39 @@ class LissenMediaSourceFactory(
         }
       }
     } ?: mediaSourceFactory.createMediaSource(mediaItem)
+  }
+
+  internal companion object {
+    /**
+     * Converts clip bounds in seconds to microseconds, tolerating corrupted metadata.
+     *
+     * Durations coming from the server can be NaN or negative, which previously produced
+     * end positions smaller than start positions and made media3 reject the clip with
+     * "IllegalArgumentException". Invalid bounds degrade to playing from the start
+     * position until the end of the file instead of crashing the playback service.
+     */
+    internal fun clipBoundsUs(
+      clipStart: Double,
+      clipEnd: Double,
+    ): Pair<Long, Long> {
+      val startUs = if (clipStart.isFinite() && clipStart > 0) (clipStart * 1_000_000).toLong() else 0L
+      val endUs =
+        when {
+          !clipEnd.isFinite() || clipEnd <= 0 -> C.TIME_UNSET
+          clipEnd * 1_000_000 <= startUs -> C.TIME_UNSET
+          else -> (clipEnd * 1_000_000).toLong()
+        }
+
+      return startUs to endUs
+    }
+
+    internal fun segmentDurationMs(
+      clipStart: Double,
+      clipEnd: Double,
+    ): Long {
+      val durationMs = ((clipEnd - clipStart) * 1000).toLong()
+
+      return if (durationMs > 0) durationMs else 1L
+    }
   }
 }

--- a/app/src/test/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactoryTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/playback/service/LissenMediaSourceFactoryTest.kt
@@ -1,0 +1,81 @@
+package org.grakovne.lissen.playback.service
+
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@OptIn(UnstableApi::class)
+class LissenMediaSourceFactoryTest {
+  @Test
+  fun `converts valid clip bounds to microseconds`() {
+    assertEquals(2_500_000L to 60_000_000L, LissenMediaSourceFactory.clipBoundsUs(2.5, 60.0))
+  }
+
+  @Test
+  fun `maps zero start to zero and keeps positive end`() {
+    assertEquals(0L to 30_000_000L, LissenMediaSourceFactory.clipBoundsUs(0.0, 30.0))
+  }
+
+  @Test
+  fun `treats NaN end as unset`() {
+    assertEquals(5_000_000L to C.TIME_UNSET, LissenMediaSourceFactory.clipBoundsUs(5.0, Double.NaN))
+  }
+
+  @Test
+  fun `treats negative end as unset`() {
+    assertEquals(0L to C.TIME_UNSET, LissenMediaSourceFactory.clipBoundsUs(0.0, -61_828.82))
+  }
+
+  @Test
+  fun `treats infinite end as unset`() {
+    assertEquals(0L to C.TIME_UNSET, LissenMediaSourceFactory.clipBoundsUs(0.0, Double.POSITIVE_INFINITY))
+  }
+
+  @Test
+  fun `treats NaN start as zero`() {
+    assertEquals(0L to 10_000_000L, LissenMediaSourceFactory.clipBoundsUs(Double.NaN, 10.0))
+  }
+
+  @Test
+  fun `treats negative start as zero`() {
+    assertEquals(0L to 10_000_000L, LissenMediaSourceFactory.clipBoundsUs(-3.0, 10.0))
+  }
+
+  @Test
+  fun `drops end position that lands before the start position`() {
+    assertEquals(5_000_000L to C.TIME_UNSET, LissenMediaSourceFactory.clipBoundsUs(5.0, 3.0))
+  }
+
+  @Test
+  fun `drops end position equal to the start position`() {
+    assertEquals(5_000_000L to C.TIME_UNSET, LissenMediaSourceFactory.clipBoundsUs(5.0, 5.0))
+  }
+
+  @Test
+  fun `never produces bounds rejected by media3`() {
+    val nasty =
+      listOf(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, -1.0, 0.0, 0.000_000_1, 12.34, 1e12)
+
+    nasty.forEach { start ->
+      nasty.forEach { end ->
+        val (startUs, endUs) = LissenMediaSourceFactory.clipBoundsUs(start, end)
+
+        assert(startUs >= 0) { "start position must not be negative for ($start, $end)" }
+        assert(endUs == C.TIME_UNSET || endUs >= startUs) { "end position must not precede start for ($start, $end)" }
+      }
+    }
+  }
+
+  @Test
+  fun `computes segment duration in milliseconds`() {
+    assertEquals(5_750L, LissenMediaSourceFactory.segmentDurationMs(2.25, 8.0))
+  }
+
+  @Test
+  fun `falls back to one millisecond when segment duration is corrupted`() {
+    assertEquals(1L, LissenMediaSourceFactory.segmentDurationMs(2.0, Double.NaN))
+    assertEquals(1L, LissenMediaSourceFactory.segmentDurationMs(8.0, 2.0))
+    assertEquals(1L, LissenMediaSourceFactory.segmentDurationMs(3.0, 3.0))
+  }
+}


### PR DESCRIPTION
Fixes Acrarium [#1767](https://acrarium.grakovne.org/app/1/bug/1767) (IllegalArgumentException in \"setEndPositionUs\", ~30 reports, still crashing on 1.11.20).

**Root cause:** chapter/file durations coming from the server can be NaN or negative. The clip end position was converted blindly (\"(clipEnd * 1_000_000).toLong()\", NaN -> 0), producing an end position below the start position, and media3 rejected the clip, crashing PlaybackService on \"setMediaItems\".

**Fix:** clip bounds now go through tolerant helpers:
- \"clipBoundsUs\": non-finite or non-positive bounds degrade to \"C.TIME_UNSET\" (play to the end of the file); clips with no real bounds skip \"ClippingMediaSource\" entirely;
- \"segmentDurationMs\": concatenated segment duration never drops below 1 ms.

**Tests:** 12 unit tests covering NaN/negative/infinite/equal bounds plus an invariant check that bounds are never rejected by media3; full unit suite is green.