### PR TITLE
fix: keep player slider range valid for corrupted durations

### DIFF
--- a/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/TrackControlComposable.kt
+++ b/app/src/main/kotlin/org/grakovne/lissen/ui/screens/player/composable/TrackControlComposable.kt
@@ -72,7 +72,7 @@ fun TrackControlComposable(
 
   LaunchedEffect(currentTrackPosition, currentTrackIndex, currentTrackDuration) {
     if (!isDragging) {
-      sliderPosition = currentTrackPosition
+      sliderPosition = safeSliderPosition(currentTrackPosition, currentTrackDuration)
     }
   }
 
@@ -104,7 +104,7 @@ fun TrackControlComposable(
           isDragging = false
           viewModel.seekTo(sliderPosition)
         },
-        valueRange = 0f..currentTrackDuration.toFloat(),
+        valueRange = 0f..safeSliderDuration(currentTrackDuration),
         colors =
           SliderDefaults.colors(
             thumbColor = colorScheme.primary,
@@ -232,4 +232,20 @@ fun TrackControlComposable(
       }
     }
   }
+}
+
+/**
+ * Corrupted chapter metadata can report a negative or non-finite duration, which made
+ * the slider build an empty range and crash on value coercion. A slider range must
+ * always start at zero and end at a non-negative value.
+ */
+internal fun safeSliderDuration(duration: Double): Float = if (duration.isFinite() && duration > 0) duration.toFloat() else 0f
+
+internal fun safeSliderPosition(
+  position: Double,
+  duration: Double,
+): Double {
+  if (!position.isFinite()) return 0.0
+
+  return position.coerceIn(0.0, safeSliderDuration(duration).toDouble())
 }

--- a/app/src/test/kotlin/org/grakovne/lissen/ui/screens/player/composable/TrackControlComposableTest.kt
+++ b/app/src/test/kotlin/org/grakovne/lissen/ui/screens/player/composable/TrackControlComposableTest.kt
@@ -1,0 +1,52 @@
+package org.grakovne.lissen.ui.screens.player.composable
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TrackControlComposableTest {
+  @Test
+  fun `keeps positive duration as slider range end`() {
+    assertEquals(120f, safeSliderDuration(120.0))
+  }
+
+  @Test
+  fun `clamps negative duration to zero so the slider range stays valid`() {
+    assertEquals(0f, safeSliderDuration(-61_828.82))
+  }
+
+  @Test
+  fun `clamps NaN duration to zero`() {
+    assertEquals(0f, safeSliderDuration(Double.NaN))
+  }
+
+  @Test
+  fun `clamps infinite duration to zero`() {
+    assertEquals(0f, safeSliderDuration(Double.POSITIVE_INFINITY))
+  }
+
+  @Test
+  fun `keeps position inside the slider range`() {
+    assertEquals(42.0, safeSliderPosition(42.0, 120.0))
+  }
+
+  @Test
+  fun `clamps position beyond the end of the track`() {
+    assertEquals(120.0, safeSliderPosition(300.0, 120.0))
+  }
+
+  @Test
+  fun `clamps negative position to zero`() {
+    assertEquals(0.0, safeSliderPosition(-5.0, 120.0))
+  }
+
+  @Test
+  fun `maps NaN position to zero`() {
+    assertEquals(0.0, safeSliderPosition(Double.NaN, 120.0))
+  }
+
+  @Test
+  fun `maps any position to zero when duration is corrupted`() {
+    assertEquals(0.0, safeSliderPosition(50.0, -61_828.82))
+    assertEquals(0.0, safeSliderPosition(50.0, Double.NaN))
+  }
+}


### PR DESCRIPTION
Fixes Acrarium [#1725](https://acrarium.grakovne.org/app/1/bug/1725) (\"Cannot coerce value to an empty range: maximum ... is less than minimum 0.0\" on the player screen).

**Root cause:** a chapter with a negative duration made the slider build the range \"0f..negative\", and value coercion threw.

**Fix:** the slider range end is clamped to a non-negative finite value (\"safeSliderDuration\"), and the displayed position is kept inside the range (\"safeSliderPosition\") including NaN positions.

**Tests:** 9 unit tests for both helpers; full unit suite is green.