### PR TITLE
fix: enable R8 minification with shrinkResources for release builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,8 +109,8 @@ android {
       if (project.hasProperty("RELEASE_STORE_FILE")) {
         signingConfig = signingConfigs.getByName("release")
       }
-      isMinifyEnabled = false
-      isShrinkResources = false
+      isMinifyEnabled = true
+      isShrinkResources = true
       proguardFiles(
         getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
       )

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -41,6 +41,12 @@
 -keep class * extends androidx.glance.appwidget.GlanceAppWidget { *; }
 -keep class * extends androidx.glance.appwidget.GlanceAppWidgetReceiver { *; }
 
+# WorkManager (pulled in by glance-appwidget) — InputMerger is instantiated via Class.newInstance().
+# work-runtime 2.7.1 consumer rules keep the class but NOT its constructor, so R8 strips it and
+# every widget update dies with "has no zero argument constructor".
+-keep class * extends androidx.work.InputMerger { <init>(); }
+-keep class androidx.work.WorkerParameters { *; }
+
 # Glance ActionCallback — class name is serialized into RemoteViews and instantiated via Class.forName() on click
 -keep class * extends androidx.glance.appwidget.action.ActionCallback { *; }
 


### PR DESCRIPTION
Keep zero-arg constructors of WorkManager InputMerger subclasses: the work-runtime 2.7.1 consumer rule keeps the class but not its constructor, so R8 stripped it and every Glance widget update failed with InstantiationException on androidx.work.OverwritingInputMerger.